### PR TITLE
feat: add UUID support and @IgnoreColumns annotation

### DIFF
--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/annotations/info/IgnoreColumn.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/annotations/info/IgnoreColumn.kt
@@ -1,5 +1,23 @@
 package ir.amirroid.ktoradmin.annotations.info
 
+/**
+ * This column will NOT be shown in the panel.
+ *
+ * Important: It still exists in the database schema and must remain valid.
+ * It should have a default value, be nullable, or be auto-generated
+ * to avoid runtime errors when data is inserted.
+ *
+ * Example:
+ * ```
+ * object Users : IntIdTable() {
+ *
+ *     @IgnoreColumn
+ *     val id = integer("id").autoIncrement()
+ *
+ *     val name = varchar("name", 100)
+ * }
+ * ```
+ */
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.SOURCE)
 annotation class IgnoreColumn

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/annotations/info/IgnoreColumns.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/annotations/info/IgnoreColumns.kt
@@ -1,0 +1,23 @@
+package ir.amirroid.ktoradmin.annotations.info
+
+/**
+ * Columns listed here will NOT be shown in the panel.
+ *
+ * Important: The table schema and database must still match these columns.
+ * They should either have a default value or be auto-generated,
+ * otherwise inserts/queries may fail.
+ *
+ * Example:
+ * ```
+ * @ExposedTable(tableName = "projects", primaryKey = "id")
+ * @IgnoreColumns(columnNames = ["id"])
+ * object Projects : UuidTable("projects") {
+ *     val name = varchar("name", 100)
+ * }
+ * ```
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+annotation class IgnoreColumns(
+    val columnNames: Array<String>,
+)

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/models/reference/EmptyColumn.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/models/reference/EmptyColumn.kt
@@ -1,3 +1,22 @@
 package ir.amirroid.ktoradmin.models.reference
 
+/**
+ * Placeholder column used when a property needs to participate in annotations
+ * or metadata processing, but does not represent a real database column.
+ *
+ * This is useful for relationship definitions and other virtual fields that
+ * should be discovered by reflection-based processors while being excluded
+ * from table schema generation.
+ *
+ * Example:
+ * ```
+ * @ManyToManyReferences(
+ *     referenceTable = "users",
+ *     junctionTable = "tasks_users",
+ *     sourceColumn = "task_id",
+ *     targetColumn = "user_id"
+ * )
+ * val users = EmptyColumn()
+ * ```
+ */
 class EmptyColumn

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/models/types/ColumnType.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/models/types/ColumnType.kt
@@ -20,6 +20,7 @@ enum class ColumnType {
     ENUMERATION,
     DATE,
     DURATION,
+    UUID,
     DATETIME,
     TIMESTAMP_WITH_TIMEZONE,
     NOT_AVAILABLE,

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/processors/exposed/ExposedTableProcessor.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/processors/exposed/ExposedTableProcessor.kt
@@ -20,6 +20,7 @@ import ir.amirroid.ktoradmin.models.common.Reference
 import ir.amirroid.ktoradmin.models.date.AutoNowDate
 import ir.amirroid.ktoradmin.models.reference.EmptyColumn
 import ir.amirroid.ktoradmin.models.types.ColumnType
+import ir.amirroid.ktoradmin.processors.qualifiedName
 import ir.amirroid.ktoradmin.repository.AnnotationRepository
 import ir.amirroid.ktoradmin.repository.PropertiesRepository
 import ir.amirroid.ktoradmin.utils.Constants
@@ -60,6 +61,7 @@ class ExposedTableProcessor(
         val fileName = FileUtils.getGeneratedFileName(simpleFileName)
         val columns = classDeclaration.getAllColumnSets()
         val generatedClass = generateClass(classDeclaration, fileName, columns)
+
         val fileSpec =
             FileSpec
                 .builder(packageName, fileName)
@@ -134,7 +136,10 @@ class ExposedTableProcessor(
     private fun KSClassDeclaration.getAllColumnSets(): List<ColumnSet> {
         val emptyColumnName = EmptyColumn::class.qualifiedName
         val columns = mutableListOf<ColumnSet>()
-        declarations.filterIsInstance<KSPropertyDeclaration>().forEach { property ->
+
+        val ignoredColumns = getIgnoredColumnNames()
+
+        getAllProperties().forEach { property ->
             val type = property.type.resolve()
             val typeName =
                 (type.declaration as? KSClassDeclaration)
@@ -143,13 +148,32 @@ class ExposedTableProcessor(
             if (typeName in COLUMN_TYPES || typeName == emptyColumnName) {
                 PropertiesRepository
                     .getColumnSetsForExposed(property, type, isEmpty = typeName == emptyColumnName)
-                    ?.let {
-                        columns += it
+                    ?.let { columnSet ->
+                        var column = columnSet
+                        if (columnSet.columnName in ignoredColumns) {
+                            column = columnSet.copy(showInPanel = false)
+                        }
+                        columns += column
                     }
             }
         }
         return columns
     }
+
+    private fun KSClassDeclaration.getIgnoredColumnNames(): Set<String> =
+        annotations
+            .firstOrNull { it.shortName.asString() == "IgnoreColumns" }
+            ?.arguments
+            ?.firstOrNull { it.name?.asString() == "columnNames" }
+            ?.value
+            ?.let { value ->
+                when (value) {
+                    is List<*> -> value.mapNotNull { it?.toString() }.toSet()
+                    is Array<*> -> value.mapNotNull { it?.toString() }.toSet()
+                    else -> setOf(value.toString())
+                }
+            }
+            ?: emptySet()
 
     private fun KSClassDeclaration.getTableName() =
         getAnnotationArguments()
@@ -196,12 +220,14 @@ class ExposedTableProcessor(
                 ?.value as? String
         )?.takeIf { it.isNotEmpty() } ?: (tableName + "s")
 
-    private fun KSClassDeclaration.getShowInAdminPanel() =
-        (
+    private fun KSClassDeclaration.getShowInAdminPanel(): Boolean {
+        val showInAdminPanel =
             getAnnotationArguments()
                 ?.find { it.name?.asString() == "showInAdminPanel" }
                 ?.value as? Boolean
-        )!!
+
+        return showInAdminPanel ?: true
+    }
 
     private fun KSClassDeclaration.getAnnotationArguments() =
         annotations
@@ -225,6 +251,8 @@ class ExposedTableProcessor(
                 "org.jetbrains.exposed.v1.dao.id.IdTable",
                 "org.jetbrains.exposed.v1.dao.id.IntIdTable",
                 "org.jetbrains.exposed.v1.dao.id.LongIdTable",
+                "org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable",
+                "org.jetbrains.exposed.v1.core.dao.id.UuidTable",
             )
     }
 }

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/processors/hibernate/HibernateTableProcessor.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/processors/hibernate/HibernateTableProcessor.kt
@@ -105,11 +105,18 @@ class HibernateTableProcessor(
         val columns = mutableListOf<ColumnSet>()
         var primaryKey: ColumnSet? = null
 
+        val ignoredColumns = getIgnoredColumnNames()
+
         getDeclaredProperties().forEach { property ->
             val type = property.type.resolve()
 
             PropertiesRepository.getColumnSetsForHibernate(property, type)?.let { columnSet ->
-                columns += columnSet
+                var column = columnSet
+                if (columnSet.columnName in ignoredColumns) {
+                    column = columnSet.copy(showInPanel = false)
+                }
+
+                columns += column
                 val idAnnotationQualifiedNames =
                     getListOfHibernatePackage(
                         HIBERNATE_ID_ANNOTATION_CLASSNAME,
@@ -122,6 +129,21 @@ class HibernateTableProcessor(
 
         return columns to (primaryKey ?: throw IllegalStateException("(${getTableName()}) No primary key found"))
     }
+
+    private fun KSClassDeclaration.getIgnoredColumnNames(): Set<String> =
+        annotations
+            .firstOrNull { it.shortName.asString() == "IgnoreColumns" }
+            ?.arguments
+            ?.firstOrNull { it.name?.asString() == "columnNames" }
+            ?.value
+            ?.let { value ->
+                when (value) {
+                    is List<*> -> value.mapNotNull { it?.toString() }.toSet()
+                    is Array<*> -> value.mapNotNull { it?.toString() }.toSet()
+                    else -> setOf(value.toString())
+                }
+            }
+            ?: emptySet()
 
     private fun KSClassDeclaration.getTableName(): String =
         annotations

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/repository/JdbcQueriesRepository.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/repository/JdbcQueriesRepository.kt
@@ -747,19 +747,19 @@ internal object JdbcQueriesRepository {
                 when (currentValue) {
                     "on" ->
                         initialValue?.lowercase() !in
-                                listOf(
-                                    "'1'",
-                                    "1",
-                                    "true",
-                                )
+                            listOf(
+                                "'1'",
+                                "1",
+                                "true",
+                            )
 
                     "off" ->
                         initialValue?.lowercase() !in
-                                listOf(
-                                    "'0'",
-                                    "0",
-                                    "false",
-                                )
+                            listOf(
+                                "'0'",
+                                "0",
+                                "false",
+                            )
 
                     else -> initialValue != currentValue
                 }
@@ -996,8 +996,8 @@ internal object JdbcQueriesRepository {
                             initialValue,
                             item.second?.first,
                         ) &&
-                                !(initialValue != null && item.second?.first == null) &&
-                                item.first.hasConfirmation.not()
+                            !(initialValue != null && item.second?.first == null) &&
+                            item.first.hasConfirmation.not()
                     }
             if (changedData.isNotEmpty() || table.getAllAutoNowDateUpdateColumns().isNotEmpty()) {
                 table

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/repository/JdbcQueriesRepository.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/repository/JdbcQueriesRepository.kt
@@ -747,19 +747,19 @@ internal object JdbcQueriesRepository {
                 when (currentValue) {
                     "on" ->
                         initialValue?.lowercase() !in
-                            listOf(
-                                "'1'",
-                                "1",
-                                "true",
-                            )
+                                listOf(
+                                    "'1'",
+                                    "1",
+                                    "true",
+                                )
 
                     "off" ->
                         initialValue?.lowercase() !in
-                            listOf(
-                                "'0'",
-                                "0",
-                                "false",
-                            )
+                                listOf(
+                                    "'0'",
+                                    "0",
+                                    "false",
+                                )
 
                     else -> initialValue != currentValue
                 }
@@ -996,8 +996,8 @@ internal object JdbcQueriesRepository {
                             initialValue,
                             item.second?.first,
                         ) &&
-                            !(initialValue != null && item.second?.first == null) &&
-                            item.first.hasConfirmation.not()
+                                !(initialValue != null && item.second?.first == null) &&
+                                item.first.hasConfirmation.not()
                     }
             if (changedData.isNotEmpty() || table.getAllAutoNowDateUpdateColumns().isNotEmpty()) {
                 table

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/repository/PropertiesRepository.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/repository/PropertiesRepository.kt
@@ -2,7 +2,6 @@ package ir.amirroid.ktoradmin.repository
 
 import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.symbol.*
-import com.squareup.kotlinpoet.ksp.toClassName
 import ir.amirroid.ktoradmin.annotations.computed.Computed
 import ir.amirroid.ktoradmin.annotations.confirmation.Confirmation
 import ir.amirroid.ktoradmin.annotations.date.AutoNowDate
@@ -210,14 +209,9 @@ object PropertiesRepository {
             if (isEmpty) {
                 null
             } else {
-                type.arguments
-                    .firstOrNull()
-                    ?.type
-                    ?.resolve()
-                    ?.toClassName()
-                    ?.canonicalName
-                    ?: return null
+                type.resolveExposedColumnType() ?: return null
             }
+
         val baseInfo = extractBaseColumnInfo(property, type)
         val enumValues = property.annotations.getEnumerations()
 
@@ -249,7 +243,7 @@ object PropertiesRepository {
                 (type.declaration as KSClassDeclaration).classKind == ClassKind.ENUM_CLASS &&
                 property.annotations.any {
                     it.qualifiedName in
-                        HibernateTableProcessor.Companion.getListOfHibernatePackage(
+                        HibernateTableProcessor.getListOfHibernatePackage(
                             "Enumerated",
                         )
                 }
@@ -257,7 +251,7 @@ object PropertiesRepository {
         // Process Hibernate-specific column annotation
         val columnAnnotation =
             property.annotations.find {
-                it.qualifiedName in HibernateTableProcessor.Companion.getListOfHibernatePackage("Column")
+                it.qualifiedName in HibernateTableProcessor.getListOfHibernatePackage("Column")
             }
 
         val hibernateReference = detectReferenceAnnotationForHibernateTable(property, type)
@@ -839,5 +833,52 @@ object PropertiesRepository {
                     "Field '$fieldName' has type '$fieldType', which is incompatible.",
             )
         }
+    }
+
+    private val ENTITY_ID_TYPES =
+        setOf(
+            "org.jetbrains.exposed.v1.core.dao.id.EntityID",
+            "org.jetbrains.exposed.dao.id.EntityID",
+        )
+
+    /**
+     * Resolves the actual column type used by Exposed columns.
+     *
+     * For regular columns:
+     * Column<String> -> String
+     *
+     * For ID columns:
+     * Column<EntityID<UUID>> -> UUID
+     *
+     * Supports both Exposed v1 package structure and legacy package names.
+     *
+     * @return The resolved column type canonical name, or null if it cannot be determined.
+     */
+    private fun KSType.resolveExposedColumnType(): String? {
+        val firstArgument =
+            arguments
+                .firstOrNull()
+                ?.type
+                ?.resolve()
+                ?: return null
+
+        val firstArgumentName =
+            (firstArgument.declaration as? KSClassDeclaration)
+                ?.qualifiedName
+                ?.asString()
+                ?: return null
+
+        if (firstArgumentName !in ENTITY_ID_TYPES) {
+            return firstArgumentName
+        }
+
+        return firstArgument
+            .arguments
+            .firstOrNull()
+            ?.type
+            ?.resolve()
+            ?.declaration
+            ?.qualifiedName
+            ?.asString()
     }
 }

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/utils/Types.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/utils/Types.kt
@@ -20,10 +20,11 @@ fun guessPropertyType(type: String) =
         "kotlin.Char" -> ColumnType.CHAR
         "kotlin.ByteArray" -> ColumnType.BINARY
         "kotlin.Boolean" -> ColumnType.BOOLEAN
-        "kotlinx.datetime.LocalDateTime", "kotlinx.datetime.Instant" -> ColumnType.DATETIME
+        "kotlinx.datetime.LocalDateTime", "kotlinx.datetime.Instant", "kotlin.time.Instant" -> ColumnType.DATETIME
         "java.time.OffsetDateTime" -> ColumnType.TIMESTAMP_WITH_TIMEZONE
         "kotlinx.datetime.LocalDate" -> ColumnType.DATE
         "kotlin.time.Duration" -> ColumnType.DURATION
+        "kotlin.uuid.Uuid" -> ColumnType.UUID
         else -> ColumnType.NOT_AVAILABLE
     }
 

--- a/src/main/kotlin/ir/amirreza/Admin.kt
+++ b/src/main/kotlin/ir/amirreza/Admin.kt
@@ -60,7 +60,6 @@ fun Application.configureAdmin(database: Database) {
         registerValueMapper(
             CustomValueMapper
         )
-        rateLimitPerMinutes = 1
         registerPreview(VideoPreview())
         registerPreview(ImagePreview())
         registerValueMapper(

--- a/src/main/kotlin/ir/amirreza/Project.kt
+++ b/src/main/kotlin/ir/amirreza/Project.kt
@@ -1,0 +1,37 @@
+package ir.amirreza
+
+import ir.amirroid.ktoradmin.annotations.exposed.ExposedTable
+import ir.amirroid.ktoradmin.annotations.info.ColumnInfo
+import ir.amirroid.ktoradmin.annotations.info.IgnoreColumns
+import org.jetbrains.exposed.v1.core.dao.id.UuidTable
+import org.jetbrains.exposed.v1.datetime.timestamp
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+
+@ExposedTable(
+    tableName = "projects",
+    primaryKey = "id"
+)
+@IgnoreColumns(columnNames = ["id"])
+object Projects : UuidTable("projects") {
+    val name = varchar("name", 100)
+    val description = text("description")
+
+    @ColumnInfo("is_active")
+    val isActive = bool("is_active").default(true)
+    val budget = decimal("budget", 12, 2)
+
+    @ColumnInfo("created_at")
+    val createdAt = timestamp("created_at")
+}
+
+
+class ProjectsService(database: Database) {
+    init {
+        transaction(database) {
+            SchemaUtils.create(Projects)
+        }
+    }
+}

--- a/src/main/kotlin/ir/amirreza/Routing.kt
+++ b/src/main/kotlin/ir/amirreza/Routing.kt
@@ -16,6 +16,7 @@ import java.io.File
 
 fun Application.configureRouting(database: Database) {
     val tasksService = TaskService(database)
+    val projectsService = ProjectsService(database)
     val userService = UserService(database)
     val tokenService = TokenService(database)
     routing {

--- a/src/main/kotlin/ir/amirreza/services/TaskService.kt
+++ b/src/main/kotlin/ir/amirreza/services/TaskService.kt
@@ -26,7 +26,7 @@ data class Task(
 )
 
 
-class TaskService(private val database: Database) {
+class TaskService(database: Database) {
     init {
         transaction(database) {
             SchemaUtils.createMissingTablesAndColumns(Tasks)


### PR DESCRIPTION
- Add UUID to `ColumnType` and implement mapping for `kotlin.uuid.Uuid`.
- Introduce `@IgnoreColumns` annotation for class-level column exclusion in Exposed and Hibernate processors.
- Improve `EntityID` type resolution to correctly extract underlying types like UUID.
- Add support for `UuidTable` in `ExposedTableProcessor`.
- Provide KDoc documentation for `IgnoreColumn`, `IgnoreColumns`, and `EmptyColumn`.
- Remove hardcoded rate limit in the sample admin configuration.