### PR TITLE
feat: add searchable autocomplete support for foreign key fields

### DIFF
--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/annotations/autocomplete/AutoComplete.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/annotations/autocomplete/AutoComplete.kt
@@ -1,0 +1,7 @@
+package ir.amirroid.ktoradmin.annotations.autocomplete
+
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.SOURCE)
+annotation class AutoComplete(
+    val searchFields: Array<String> = [],
+)

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/configuration/DynamicConfiguration.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/configuration/DynamicConfiguration.kt
@@ -125,6 +125,9 @@ internal object DynamicConfiguration {
 
     var menuProvider: ((String?) -> List<Menu>)? = null
 
+    /** Page size for autocomplete search results */
+    var autocompletePageSize: Int = 20
+
     /**
      * Registers a new value mapper.
      * @param valueMapper The value mapper to register.

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/configuration/KtorAdminConfiguration.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/configuration/KtorAdminConfiguration.kt
@@ -142,6 +142,15 @@ class KtorAdminConfiguration {
         }
 
     /**
+     * Page size for autocomplete search results.
+     */
+    var autoCompletePageSize: Int
+        get() = DynamicConfiguration.autocompletePageSize
+        set(value) {
+            DynamicConfiguration.autocompletePageSize = value
+        }
+
+    /**
      * TinyMCE editor configuration.
      */
     var tinyMCEConfig: TinyMCEConfig

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/models/ColumnSet.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/models/ColumnSet.kt
@@ -47,7 +47,10 @@ import java.time.OffsetDateTime
  * @property valueMapper Defines a transformation or mapping function to process values before displaying or storing them.
  *                        This can be used to convert data formats, apply specific parsing rules, or format values dynamically.
  * @property preview A key used in `KtorAdminPreview` to reference a preview of this column's content, if applicable.
- *                        This is useful for fields that require visual representation, such as images or rich content.
+ * @property hasAutoComplete Whether this column should be rendered as a searchable autocomplete dropdown.
+ *                           Only valid for columns with a Many-to-One or One-to-One Reference. Defaults to `false`.
+ * @property autoCompleteSearchFields List of field names from the referenced entity to search against.
+ *                                   If empty, uses the referenced table's default searches. Defaults to empty.
  */
 data class ColumnSet(
     val columnName: String,
@@ -73,6 +76,8 @@ data class ColumnSet(
     val valueMapper: String? = null,
     val preview: String? = null,
     val defaultValueProviderKey: String? = null,
+    val hasAutoComplete: Boolean = false,
+    val autoCompleteSearchFields: List<String> = emptyList(),
 )
 
 internal fun ColumnSet.getCurrentDateClass() =

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/modules/Routing.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/modules/Routing.kt
@@ -3,6 +3,7 @@ package ir.amirroid.ktoradmin.modules
 import io.ktor.server.application.*
 import io.ktor.server.http.content.*
 import io.ktor.server.routing.*
+import ir.amirroid.ktoradmin.modules.autocomplete.configureAutoCompleteRouting
 import ir.amirroid.ktoradmin.modules.download.configureDownloadFilesRouting
 import ir.amirroid.ktoradmin.modules.file.handleGenerateFileUrl
 import ir.amirroid.ktoradmin.modules.uploads.configureUploadFileRouting
@@ -22,5 +23,6 @@ fun Application.configureRouting(
         handleGenerateFileUrl(panels, authenticateName)
         configureGetRouting(panels, authenticateName)
         configureSavesRouting(panels, authenticateName)
+        configureAutoCompleteRouting(panels, authenticateName)
     }
 }

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/modules/autocomplete/AutoCompleteController.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/modules/autocomplete/AutoCompleteController.kt
@@ -1,0 +1,111 @@
+package ir.amirroid.ktoradmin.modules.autocomplete
+
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.Routing
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import ir.amirroid.ktoradmin.configuration.DynamicConfiguration
+import ir.amirroid.ktoradmin.models.common.Reference
+import ir.amirroid.ktoradmin.models.common.tableName
+import ir.amirroid.ktoradmin.panels.AdminJdbcTable
+import ir.amirroid.ktoradmin.panels.AdminPanel
+import ir.amirroid.ktoradmin.panels.findWithPluralName
+import ir.amirroid.ktoradmin.repository.JdbcQueriesRepository
+import ir.amirroid.ktoradmin.utils.withAuthenticate
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AutoCompleteRequest(
+    val search: String = "",
+    val page: Int = 0,
+)
+
+@Serializable
+data class AutoCompleteResponse(
+    val items: List<AutoCompleteItem>,
+    val totalCount: Int,
+)
+
+@Serializable
+data class AutoCompleteItem(
+    val key: String,
+    val label: String,
+)
+
+/**
+ * Configures the autocomplete routing endpoints.
+ * This provides a generic autocomplete endpoint for foreign key fields
+ * annotated with @AutoComplete.
+ *
+ * Route: POST /{adminPath}/autocomplete/{tableName}/{columnName}
+ *
+ * The columnName parameter is required to resolve the specific ColumnSet
+ * and its autoCompleteSearchFields from metadata.
+ *
+ * Resolution logic:
+ * 1. Find owner table (e.g., "tasks") from tableName
+ * 2. Find ColumnSet (e.g., "user_id") from columnName
+ * 3. Get referenced table (e.g., "users") from columnSet.reference
+ * 4. Search against the referenced table using autoCompleteSearchFields
+ */
+internal fun Routing.configureAutoCompleteRouting(
+    panels: List<AdminPanel>,
+    authenticateName: String? = null,
+) {
+    withAuthenticate(authenticateName) {
+        route("/${DynamicConfiguration.adminPath}/autocomplete") {
+            post("/{tableName}/{columnName}") {
+                val tableName = call.parameters["tableName"] ?: ""
+                val columnName = call.parameters["columnName"] ?: ""
+
+                val ownerTable = panels.findWithPluralName(tableName) as? AdminJdbcTable
+                if (ownerTable == null) {
+                    call.respondText { "Table not found: $tableName" }
+                    return@post
+                }
+
+                val columnSet = ownerTable.getAllColumns().find { it.columnName == columnName }
+                if (columnSet == null || !columnSet.hasAutoComplete) {
+                    call.respondText { "Autocomplete field not found: $columnName" }
+                    return@post
+                }
+
+                val reference = columnSet.reference
+                if (reference == null || (reference !is Reference.ManyToOne && reference !is Reference.OneToOne)) {
+                    call.respondText { "Invalid reference type for autocomplete field: $columnName" }
+                    return@post
+                }
+
+                val referencedTableName = reference.tableName
+                val referencedTable = panels.find { panel ->
+                    panel is AdminJdbcTable && panel.getTableName() == referencedTableName
+                } as? AdminJdbcTable
+
+                if (referencedTable == null) {
+                    call.respondText { "Referenced table not found: $referencedTableName" }
+                    return@post
+                }
+
+                val request = call.receive<AutoCompleteRequest>()
+                val search = request.search.takeIf { it.isNotBlank() }
+                val page = request.page.coerceAtLeast(0)
+
+                val pageSize = DynamicConfiguration.autocompletePageSize
+
+                val searchFields = columnSet.autoCompleteSearchFields
+
+                val results = JdbcQueriesRepository.searchReferences(
+                    table = referencedTable,
+                    search = search,
+                    page = page,
+                    pageSize = pageSize,
+                    searchFields = searchFields,
+                )
+
+                call.respond(results)
+            }
+        }
+    }
+}

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/modules/autocomplete/AutoCompleteController.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/modules/autocomplete/AutoCompleteController.kt
@@ -79,9 +79,10 @@ internal fun Routing.configureAutoCompleteRouting(
                 }
 
                 val referencedTableName = reference.tableName
-                val referencedTable = panels.find { panel ->
-                    panel is AdminJdbcTable && panel.getTableName() == referencedTableName
-                } as? AdminJdbcTable
+                val referencedTable =
+                    panels.find { panel ->
+                        panel is AdminJdbcTable && panel.getTableName() == referencedTableName
+                    } as? AdminJdbcTable
 
                 if (referencedTable == null) {
                     call.respondText { "Referenced table not found: $referencedTableName" }
@@ -96,13 +97,14 @@ internal fun Routing.configureAutoCompleteRouting(
 
                 val searchFields = columnSet.autoCompleteSearchFields
 
-                val results = JdbcQueriesRepository.searchReferences(
-                    table = referencedTable,
-                    search = search,
-                    page = page,
-                    pageSize = pageSize,
-                    searchFields = searchFields,
-                )
+                val results =
+                    JdbcQueriesRepository.searchReferences(
+                        table = referencedTable,
+                        search = search,
+                        page = page,
+                        pageSize = pageSize,
+                        searchFields = searchFields,
+                    )
 
                 call.respond(results)
             }

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/repository/JdbcQueriesRepository.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/repository/JdbcQueriesRepository.kt
@@ -738,6 +738,263 @@ internal object JdbcQueriesRepository {
         }
 
     /**
+     * Searches references with pagination support for autocomplete.
+     * @param table Target database table
+     * @param search Search string to filter results
+     * @param page Page number for pagination (0-based)
+     * @param pageSize Number of items per page
+     * @param searchFields Optional list of fields to search against (from @AutoComplete annotation)
+     * @return AutoCompleteResponse containing matched items and total count
+     */
+    fun searchReferences(
+        table: AdminJdbcTable,
+        search: String?,
+        page: Int,
+        pageSize: Int,
+        searchFields: List<String> = emptyList(),
+    ): ir.amirroid.ktoradmin.modules.autocomplete.AutoCompleteResponse {
+        val results = mutableListOf<ir.amirroid.ktoradmin.modules.autocomplete.AutoCompleteItem>()
+        var totalCount = 0L
+
+        table.usingDataSource { session ->
+            val countQuery = createSearchReferencesCountQuery(table, search, searchFields)
+            session.prepare(sqlQuery(countQuery)).use { preparedStatement ->
+                search?.let { preparedStatement.setString(1, "%$it%") }
+                preparedStatement.executeQuery().use { rs ->
+                    if (rs.next()) {
+                        totalCount = rs.getLong(1)
+                    }
+                }
+            }
+
+            val dataQuery = createSearchReferencesQuery(table, search, page, pageSize, searchFields)
+            session.prepare(sqlQuery(dataQuery)).use { preparedStatement ->
+                var paramIndex = 1
+                search?.let { preparedStatement.setString(paramIndex++, "%$it%") }
+                preparedStatement.setInt(paramIndex++, pageSize)
+                preparedStatement.setInt(paramIndex, page * pageSize)
+
+                preparedStatement.executeQuery().use { rs ->
+                    while (rs.next()) {
+                        val key = rs.getObject(table.getPrimaryKey())?.toString() ?: ""
+                        val displayFormat = table.getDisplayFormat()
+                        val label = buildDisplayLabel(rs, table, key, displayFormat)
+                        results.add(
+                            ir.amirroid.ktoradmin.modules.autocomplete.AutoCompleteItem(
+                                key = key,
+                                label = label,
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+
+        return ir.amirroid.ktoradmin.modules.autocomplete.AutoCompleteResponse(
+            items = results,
+            totalCount = totalCount.toInt(),
+        )
+    }
+
+    /**
+     * Builds display label using the same logic as getAllReferences.
+     * Uses populateTemplate to respect {column} syntax in display format.
+     */
+    private fun buildDisplayLabel(
+        rs: java.sql.ResultSet,
+        table: AdminJdbcTable,
+        primaryKeyValue: String,
+        displayFormat: String?,
+    ): String {
+        if (displayFormat == null) {
+            return "${table.getSingularName().replaceFirstChar { it.uppercaseChar() }} Object ($primaryKeyValue)"
+        }
+
+        val displayFormatValues = displayFormat.extractTextInCurlyBraces()
+        val values = displayFormatValues.associateWith { column ->
+            if (column == table.getPrimaryKey()) {
+                primaryKeyValue
+            } else {
+                val splitItem = column.split(".")
+                val columnSet = table.getAllColumns().firstOrNull { it.columnName == splitItem.last() }
+                val columnName = splitItem.joinToString("_")
+                val rawValue = rs.getObject(columnName)
+                if (columnSet == null) {
+                    rawValue?.toString()
+                } else {
+                    rawValue
+                        .restore(columnSet)
+                        .formatToDisplayInTable(columnSet.type)
+                }
+            }
+        }
+        return populateTemplate(displayFormat, values)
+    }
+
+    /**
+     * Creates a search query for autocomplete with pagination.
+     * Uses the same column aliasing as getAllReferences to support proper display format.
+     */
+    private fun createSearchReferencesQuery(
+        table: AdminJdbcTable,
+        search: String?,
+        page: Int,
+        pageSize: Int,
+        searchFields: List<String> = emptyList(),
+    ): String = buildString {
+        val tableName = table.getTableName()
+        val primaryKey = table.getPrimaryKey()
+
+        // For autocomplete, use ONLY the specified searchFields, not table.getSearches()
+        // If searchFields is empty, no search filtering is applied (return all results)
+        val effectiveSearchColumns = searchFields
+
+        // Build select columns using the same aliasing as getAllReferences
+        val selectColumns = mutableSetOf<String>()
+        val joins = mutableSetOf<String>()
+        val aliasMap = mutableMapOf<String, String>()
+
+        selectColumns.add("$tableName.$primaryKey AS $primaryKey")
+
+        // Include columns needed for display format
+        val displayFormat = table.getDisplayFormat()
+        if (displayFormat != null) {
+            val displayFormatValues = displayFormat.extractTextInCurlyBraces()
+            displayFormatValues.forEach { column ->
+                if (column.contains('.')) {
+                    // Handle nested references like user.username
+                    var currentTable = tableName
+                    var currentColumn = ""
+                    val path = column.split('.')
+                    for (i in path.indices) {
+                        val referenceColumn = path[i]
+                        val nextColumn = path.getOrNull(i + 1)
+                        val columnSet = table.getAllColumns().find { it.columnName == referenceColumn }
+                        val reference = columnSet?.reference
+
+                        if (reference != null) {
+                            val joinTable = reference.tableName
+                            val joinAlias = aliasMap.getOrPut(joinTable) { "${joinTable}_REF" }
+                            val joinCondition = when (reference) {
+                                is ir.amirroid.ktoradmin.models.common.Reference.OneToOne,
+                                is ir.amirroid.ktoradmin.models.common.Reference.ManyToOne -> {
+                                    val joinColumn = reference.foreignKey
+                                    "LEFT JOIN $joinTable AS $joinAlias ON $currentTable.$referenceColumn = $joinAlias.$joinColumn"
+                                }
+                                else -> null
+                            }
+                            if (joinCondition != null && joinCondition !in joins) {
+                                joins.add(joinCondition)
+                            }
+                            currentTable = joinAlias
+                            currentColumn = nextColumn ?: referenceColumn
+                        } else if (i == path.lastIndex) {
+                            currentColumn = referenceColumn
+                        }
+                    }
+                    if (currentColumn.isNotEmpty()) {
+                        selectColumns.add("$currentTable.$currentColumn AS ${path.joinToString("_")}")
+                    }
+                } else {
+                    if (column != primaryKey) {
+                        selectColumns.add("$tableName.$column AS $column")
+                    }
+                }
+            }
+        }
+
+        append("SELECT DISTINCT ")
+        append(selectColumns.joinToString(", "))
+        append(" FROM ")
+        append(tableName)
+        joins.forEach { append(" $it") }
+
+        // Add search conditions ONLY against the specified autoCompleteSearchFields
+        // Only apply WHERE clause if we have both search text AND search fields configured
+        if (search != null && effectiveSearchColumns.isNotEmpty()) {
+            append(" WHERE ")
+            val searchConditions = effectiveSearchColumns.map { searchCol ->
+                // Search can be against simple columns or nested references
+                if (searchCol.contains('.')) {
+                    val pathParts = searchCol.split('.')
+                    var currentTable = tableName
+                    for (i in pathParts.indices) {
+                        val referenceColumn = pathParts[i]
+                        val columnSet = table.getAllColumns().find { it.columnName == referenceColumn }
+                        val reference = columnSet?.reference
+                        if (reference != null) {
+                            val joinTable = reference.tableName
+                            val joinAlias = aliasMap.getOrPut(joinTable) { "${joinTable}_REF" }
+                            val joinCondition = when (reference) {
+                                is ir.amirroid.ktoradmin.models.common.Reference.OneToOne,
+                                is ir.amirroid.ktoradmin.models.common.Reference.ManyToOne -> {
+                                    val joinColumn = reference.foreignKey
+                                    "LEFT JOIN $joinTable AS $joinAlias ON $currentTable.$referenceColumn = $joinAlias.$joinColumn"
+                                }
+                                else -> null
+                            }
+                            if (joinCondition != null && joinCondition !in joins) {
+                                joins.add(joinCondition)
+                            }
+                            currentTable = joinAlias
+                        }
+                    }
+                    "LOWER(${currentTable}.${pathParts.last()}) LIKE LOWER(?)"
+                } else {
+                    "LOWER($tableName.$searchCol) LIKE LOWER(?)"
+                }
+            }
+            append(searchConditions.joinToString(" OR "))
+        }
+
+        // Add ordering - always include primary key for stable pagination
+        val order = table.getDefaultOrder()
+        if (order != null &&
+            order.name in table.getAllColumns().map { col -> col.columnName } &&
+            order.direction.lowercase() in listOf("asc", "desc")
+        ) {
+            append(" ORDER BY $tableName.${order.name} ${order.direction}")
+        } else {
+            // Fallback to primary key for deterministic ordering
+            append(" ORDER BY $tableName.$primaryKey ASC")
+        }
+
+        // Add pagination
+        append(" LIMIT ? OFFSET ?")
+    }
+
+    /**
+     * Creates a count query for autocomplete search.
+     */
+    private fun createSearchReferencesCountQuery(
+        table: AdminJdbcTable,
+        search: String?,
+        searchFields: List<String> = emptyList(),
+    ): String = buildString {
+        // For autocomplete, use ONLY the specified searchFields, not table.getSearches()
+        val effectiveSearchColumns = searchFields
+        val tableName = table.getTableName()
+
+        append("SELECT COUNT(*) FROM ")
+        append(tableName)
+
+        // Only apply WHERE clause if we have both search text AND search fields configured
+        if (search != null && effectiveSearchColumns.isNotEmpty()) {
+            append(" WHERE ")
+            val searchConditions = effectiveSearchColumns.map { searchCol ->
+                if (searchCol.contains('.')) {
+                    // For nested references, we need to handle joins
+                    // Simplified: assume the column is in the main table for now
+                    "LOWER($tableName.$searchCol) LIKE LOWER(?)"
+                } else {
+                    "LOWER($tableName.$searchCol) LIKE LOWER(?)"
+                }
+            }
+            append(searchConditions.joinToString(" OR "))
+        }
+    }
+
+    /**
      * Checks if data has been changed compared to initial value.
      */
     private fun checkIsChangedData(

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/repository/JdbcQueriesRepository.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/repository/JdbcQueriesRepository.kt
@@ -811,23 +811,24 @@ internal object JdbcQueriesRepository {
         }
 
         val displayFormatValues = displayFormat.extractTextInCurlyBraces()
-        val values = displayFormatValues.associateWith { column ->
-            if (column == table.getPrimaryKey()) {
-                primaryKeyValue
-            } else {
-                val splitItem = column.split(".")
-                val columnSet = table.getAllColumns().firstOrNull { it.columnName == splitItem.last() }
-                val columnName = splitItem.joinToString("_")
-                val rawValue = rs.getObject(columnName)
-                if (columnSet == null) {
-                    rawValue?.toString()
+        val values =
+            displayFormatValues.associateWith { column ->
+                if (column == table.getPrimaryKey()) {
+                    primaryKeyValue
                 } else {
-                    rawValue
-                        .restore(columnSet)
-                        .formatToDisplayInTable(columnSet.type)
+                    val splitItem = column.split(".")
+                    val columnSet = table.getAllColumns().firstOrNull { it.columnName == splitItem.last() }
+                    val columnName = splitItem.joinToString("_")
+                    val rawValue = rs.getObject(columnName)
+                    if (columnSet == null) {
+                        rawValue?.toString()
+                    } else {
+                        rawValue
+                            .restore(columnSet)
+                            .formatToDisplayInTable(columnSet.type)
+                    }
                 }
             }
-        }
         return populateTemplate(displayFormat, values)
     }
 
@@ -841,127 +842,133 @@ internal object JdbcQueriesRepository {
         page: Int,
         pageSize: Int,
         searchFields: List<String> = emptyList(),
-    ): String = buildString {
-        val tableName = table.getTableName()
-        val primaryKey = table.getPrimaryKey()
+    ): String =
+        buildString {
+            val tableName = table.getTableName()
+            val primaryKey = table.getPrimaryKey()
 
-        // For autocomplete, use ONLY the specified searchFields, not table.getSearches()
-        // If searchFields is empty, no search filtering is applied (return all results)
-        val effectiveSearchColumns = searchFields
+            // For autocomplete, use ONLY the specified searchFields, not table.getSearches()
+            // If searchFields is empty, no search filtering is applied (return all results)
+            val effectiveSearchColumns = searchFields
 
-        // Build select columns using the same aliasing as getAllReferences
-        val selectColumns = mutableSetOf<String>()
-        val joins = mutableSetOf<String>()
-        val aliasMap = mutableMapOf<String, String>()
+            // Build select columns using the same aliasing as getAllReferences
+            val selectColumns = mutableSetOf<String>()
+            val joins = mutableSetOf<String>()
+            val aliasMap = mutableMapOf<String, String>()
 
-        selectColumns.add("$tableName.$primaryKey AS $primaryKey")
+            selectColumns.add("$tableName.$primaryKey AS $primaryKey")
 
-        // Include columns needed for display format
-        val displayFormat = table.getDisplayFormat()
-        if (displayFormat != null) {
-            val displayFormatValues = displayFormat.extractTextInCurlyBraces()
-            displayFormatValues.forEach { column ->
-                if (column.contains('.')) {
-                    // Handle nested references like user.username
-                    var currentTable = tableName
-                    var currentColumn = ""
-                    val path = column.split('.')
-                    for (i in path.indices) {
-                        val referenceColumn = path[i]
-                        val nextColumn = path.getOrNull(i + 1)
-                        val columnSet = table.getAllColumns().find { it.columnName == referenceColumn }
-                        val reference = columnSet?.reference
+            // Include columns needed for display format
+            val displayFormat = table.getDisplayFormat()
+            if (displayFormat != null) {
+                val displayFormatValues = displayFormat.extractTextInCurlyBraces()
+                displayFormatValues.forEach { column ->
+                    if (column.contains('.')) {
+                        // Handle nested references like user.username
+                        var currentTable = tableName
+                        var currentColumn = ""
+                        val path = column.split('.')
+                        for (i in path.indices) {
+                            val referenceColumn = path[i]
+                            val nextColumn = path.getOrNull(i + 1)
+                            val columnSet = table.getAllColumns().find { it.columnName == referenceColumn }
+                            val reference = columnSet?.reference
 
-                        if (reference != null) {
-                            val joinTable = reference.tableName
-                            val joinAlias = aliasMap.getOrPut(joinTable) { "${joinTable}_REF" }
-                            val joinCondition = when (reference) {
-                                is ir.amirroid.ktoradmin.models.common.Reference.OneToOne,
-                                is ir.amirroid.ktoradmin.models.common.Reference.ManyToOne -> {
-                                    val joinColumn = reference.foreignKey
-                                    "LEFT JOIN $joinTable AS $joinAlias ON $currentTable.$referenceColumn = $joinAlias.$joinColumn"
+                            if (reference != null) {
+                                val joinTable = reference.tableName
+                                val joinAlias = aliasMap.getOrPut(joinTable) { "${joinTable}_REF" }
+                                val joinCondition =
+                                    when (reference) {
+                                        is ir.amirroid.ktoradmin.models.common.Reference.OneToOne,
+                                        is ir.amirroid.ktoradmin.models.common.Reference.ManyToOne,
+                                        -> {
+                                            val joinColumn = reference.foreignKey
+                                            "LEFT JOIN $joinTable AS $joinAlias ON $currentTable.$referenceColumn = $joinAlias.$joinColumn"
+                                        }
+                                        else -> null
+                                    }
+                                if (joinCondition != null && joinCondition !in joins) {
+                                    joins.add(joinCondition)
                                 }
-                                else -> null
+                                currentTable = joinAlias
+                                currentColumn = nextColumn ?: referenceColumn
+                            } else if (i == path.lastIndex) {
+                                currentColumn = referenceColumn
                             }
-                            if (joinCondition != null && joinCondition !in joins) {
-                                joins.add(joinCondition)
-                            }
-                            currentTable = joinAlias
-                            currentColumn = nextColumn ?: referenceColumn
-                        } else if (i == path.lastIndex) {
-                            currentColumn = referenceColumn
                         }
-                    }
-                    if (currentColumn.isNotEmpty()) {
-                        selectColumns.add("$currentTable.$currentColumn AS ${path.joinToString("_")}")
-                    }
-                } else {
-                    if (column != primaryKey) {
-                        selectColumns.add("$tableName.$column AS $column")
+                        if (currentColumn.isNotEmpty()) {
+                            selectColumns.add("$currentTable.$currentColumn AS ${path.joinToString("_")}")
+                        }
+                    } else {
+                        if (column != primaryKey) {
+                            selectColumns.add("$tableName.$column AS $column")
+                        }
                     }
                 }
             }
-        }
 
-        append("SELECT DISTINCT ")
-        append(selectColumns.joinToString(", "))
-        append(" FROM ")
-        append(tableName)
-        joins.forEach { append(" $it") }
+            append("SELECT DISTINCT ")
+            append(selectColumns.joinToString(", "))
+            append(" FROM ")
+            append(tableName)
+            joins.forEach { append(" $it") }
 
-        // Add search conditions ONLY against the specified autoCompleteSearchFields
-        // Only apply WHERE clause if we have both search text AND search fields configured
-        if (search != null && effectiveSearchColumns.isNotEmpty()) {
-            append(" WHERE ")
-            val searchConditions = effectiveSearchColumns.map { searchCol ->
-                // Search can be against simple columns or nested references
-                if (searchCol.contains('.')) {
-                    val pathParts = searchCol.split('.')
-                    var currentTable = tableName
-                    for (i in pathParts.indices) {
-                        val referenceColumn = pathParts[i]
-                        val columnSet = table.getAllColumns().find { it.columnName == referenceColumn }
-                        val reference = columnSet?.reference
-                        if (reference != null) {
-                            val joinTable = reference.tableName
-                            val joinAlias = aliasMap.getOrPut(joinTable) { "${joinTable}_REF" }
-                            val joinCondition = when (reference) {
-                                is ir.amirroid.ktoradmin.models.common.Reference.OneToOne,
-                                is ir.amirroid.ktoradmin.models.common.Reference.ManyToOne -> {
-                                    val joinColumn = reference.foreignKey
-                                    "LEFT JOIN $joinTable AS $joinAlias ON $currentTable.$referenceColumn = $joinAlias.$joinColumn"
+            // Add search conditions ONLY against the specified autoCompleteSearchFields
+            // Only apply WHERE clause if we have both search text AND search fields configured
+            if (search != null && effectiveSearchColumns.isNotEmpty()) {
+                append(" WHERE ")
+                val searchConditions =
+                    effectiveSearchColumns.map { searchCol ->
+                        // Search can be against simple columns or nested references
+                        if (searchCol.contains('.')) {
+                            val pathParts = searchCol.split('.')
+                            var currentTable = tableName
+                            for (i in pathParts.indices) {
+                                val referenceColumn = pathParts[i]
+                                val columnSet = table.getAllColumns().find { it.columnName == referenceColumn }
+                                val reference = columnSet?.reference
+                                if (reference != null) {
+                                    val joinTable = reference.tableName
+                                    val joinAlias = aliasMap.getOrPut(joinTable) { "${joinTable}_REF" }
+                                    val joinCondition =
+                                        when (reference) {
+                                            is ir.amirroid.ktoradmin.models.common.Reference.OneToOne,
+                                            is ir.amirroid.ktoradmin.models.common.Reference.ManyToOne,
+                                            -> {
+                                                val joinColumn = reference.foreignKey
+                                                "LEFT JOIN $joinTable AS $joinAlias ON $currentTable.$referenceColumn = $joinAlias.$joinColumn"
+                                            }
+                                            else -> null
+                                        }
+                                    if (joinCondition != null && joinCondition !in joins) {
+                                        joins.add(joinCondition)
+                                    }
+                                    currentTable = joinAlias
                                 }
-                                else -> null
                             }
-                            if (joinCondition != null && joinCondition !in joins) {
-                                joins.add(joinCondition)
-                            }
-                            currentTable = joinAlias
+                            "LOWER($currentTable.${pathParts.last()}) LIKE LOWER(?)"
+                        } else {
+                            "LOWER($tableName.$searchCol) LIKE LOWER(?)"
                         }
                     }
-                    "LOWER(${currentTable}.${pathParts.last()}) LIKE LOWER(?)"
-                } else {
-                    "LOWER($tableName.$searchCol) LIKE LOWER(?)"
-                }
+                append(searchConditions.joinToString(" OR "))
             }
-            append(searchConditions.joinToString(" OR "))
-        }
 
-        // Add ordering - always include primary key for stable pagination
-        val order = table.getDefaultOrder()
-        if (order != null &&
-            order.name in table.getAllColumns().map { col -> col.columnName } &&
-            order.direction.lowercase() in listOf("asc", "desc")
-        ) {
-            append(" ORDER BY $tableName.${order.name} ${order.direction}")
-        } else {
-            // Fallback to primary key for deterministic ordering
-            append(" ORDER BY $tableName.$primaryKey ASC")
-        }
+            // Add ordering - always include primary key for stable pagination
+            val order = table.getDefaultOrder()
+            if (order != null &&
+                order.name in table.getAllColumns().map { col -> col.columnName } &&
+                order.direction.lowercase() in listOf("asc", "desc")
+            ) {
+                append(" ORDER BY $tableName.${order.name} ${order.direction}")
+            } else {
+                // Fallback to primary key for deterministic ordering
+                append(" ORDER BY $tableName.$primaryKey ASC")
+            }
 
-        // Add pagination
-        append(" LIMIT ? OFFSET ?")
-    }
+            // Add pagination
+            append(" LIMIT ? OFFSET ?")
+        }
 
     /**
      * Creates a count query for autocomplete search.
@@ -970,29 +977,31 @@ internal object JdbcQueriesRepository {
         table: AdminJdbcTable,
         search: String?,
         searchFields: List<String> = emptyList(),
-    ): String = buildString {
-        // For autocomplete, use ONLY the specified searchFields, not table.getSearches()
-        val effectiveSearchColumns = searchFields
-        val tableName = table.getTableName()
+    ): String =
+        buildString {
+            // For autocomplete, use ONLY the specified searchFields, not table.getSearches()
+            val effectiveSearchColumns = searchFields
+            val tableName = table.getTableName()
 
-        append("SELECT COUNT(*) FROM ")
-        append(tableName)
+            append("SELECT COUNT(*) FROM ")
+            append(tableName)
 
-        // Only apply WHERE clause if we have both search text AND search fields configured
-        if (search != null && effectiveSearchColumns.isNotEmpty()) {
-            append(" WHERE ")
-            val searchConditions = effectiveSearchColumns.map { searchCol ->
-                if (searchCol.contains('.')) {
-                    // For nested references, we need to handle joins
-                    // Simplified: assume the column is in the main table for now
-                    "LOWER($tableName.$searchCol) LIKE LOWER(?)"
-                } else {
-                    "LOWER($tableName.$searchCol) LIKE LOWER(?)"
-                }
+            // Only apply WHERE clause if we have both search text AND search fields configured
+            if (search != null && effectiveSearchColumns.isNotEmpty()) {
+                append(" WHERE ")
+                val searchConditions =
+                    effectiveSearchColumns.map { searchCol ->
+                        if (searchCol.contains('.')) {
+                            // For nested references, we need to handle joins
+                            // Simplified: assume the column is in the main table for now
+                            "LOWER($tableName.$searchCol) LIKE LOWER(?)"
+                        } else {
+                            "LOWER($tableName.$searchCol) LIKE LOWER(?)"
+                        }
+                    }
+                append(searchConditions.joinToString(" OR "))
             }
-            append(searchConditions.joinToString(" OR "))
         }
-    }
 
     /**
      * Checks if data has been changed compared to initial value.

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/repository/PropertiesRepository.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/repository/PropertiesRepository.kt
@@ -3,6 +3,7 @@ package ir.amirroid.ktoradmin.repository
 import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.symbol.*
 import ir.amirroid.ktoradmin.annotations.computed.Computed
+import ir.amirroid.ktoradmin.annotations.autocomplete.AutoComplete
 import ir.amirroid.ktoradmin.annotations.confirmation.Confirmation
 import ir.amirroid.ktoradmin.annotations.date.AutoNowDate
 import ir.amirroid.ktoradmin.annotations.defaultvalue.DefaultValueProvider
@@ -156,6 +157,10 @@ object PropertiesRepository {
         val hasTextAreaField = hasTextAreaFieldAnnotation(property.annotations)
         validateTextArea(hasTextAreaField, columnType)
 
+        val hasAutoComplete = hasAutoCompleteAnnotation(property.annotations)
+        val autoCompleteSearchFields = getAutoCompleteSearchFields(property.annotations)
+        validateAutoComplete(hasAutoComplete, reference)
+
         // Construct and return the final ColumnSet configuration
         return ColumnSet(
             columnName = baseInfo.columnName,
@@ -191,6 +196,8 @@ object PropertiesRepository {
             defaultValueProviderKey = getDefaultValueProviderAnnotation(property.annotations),
             preview = getPreviewAnnotation(property.annotations),
             hasTextArea = hasTextAreaField,
+            hasAutoComplete = hasAutoComplete,
+            autoCompleteSearchFields = autoCompleteSearchFields,
         )
     }
 
@@ -561,6 +568,26 @@ object PropertiesRepository {
         annotations.any { it.qualifiedName == Enumeration::class.qualifiedName }
 
     /**
+     * Checks if a property has the AutoComplete annotation.
+     */
+    private fun hasAutoCompleteAnnotation(annotations: Sequence<KSAnnotation>): Boolean =
+        annotations.any { it.qualifiedName == AutoComplete::class.qualifiedName }
+
+    /**
+     * Extracts search fields from AutoComplete annotation.
+     */
+    private fun getAutoCompleteSearchFields(annotations: Sequence<KSAnnotation>): List<String> =
+        annotations
+            .firstOrNull { it.qualifiedName == AutoComplete::class.qualifiedName }
+            ?.arguments
+            ?.firstOrNull { it.name?.asString() == "searchFields" }
+            ?.value
+            ?.let { it as? List<*> }
+            ?.filterIsInstance<String>()
+            ?.takeIf { it.isNotEmpty() }
+            ?: emptyList()
+
+    /**
      * Checks if a property has the RichEditor annotation.
      */
     private fun hasRichEditorAnnotation(annotations: Sequence<KSAnnotation>): Boolean = annotations.any { it.qualifiedName == RichEditor::class.qualifiedName }
@@ -819,6 +846,25 @@ object PropertiesRepository {
     ) {
         if (hasTextArea && columnType != ColumnType.STRING) {
             throw IllegalArgumentException("Text area can only be used with columns of type STRING.")
+        }
+    }
+
+    /**
+     * Validates AutoComplete configuration.
+     */
+    private fun validateAutoComplete(
+        hasAutoComplete: Boolean,
+        reference: Reference?,
+    ) {
+        if (hasAutoComplete && reference == null) {
+            throw IllegalArgumentException(
+                "@AutoComplete can only be used on columns with a reference (ManyToOneReferences or OneToOneReferences).",
+            )
+        }
+        if (hasAutoComplete && reference is Reference.ManyToMany) {
+            throw IllegalArgumentException(
+                "@AutoComplete cannot be used with ManyToMany references. Use a standard select for ManyToMany fields.",
+            )
         }
     }
 

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/repository/PropertiesRepository.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/repository/PropertiesRepository.kt
@@ -2,8 +2,8 @@ package ir.amirroid.ktoradmin.repository
 
 import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.symbol.*
-import ir.amirroid.ktoradmin.annotations.computed.Computed
 import ir.amirroid.ktoradmin.annotations.autocomplete.AutoComplete
+import ir.amirroid.ktoradmin.annotations.computed.Computed
 import ir.amirroid.ktoradmin.annotations.confirmation.Confirmation
 import ir.amirroid.ktoradmin.annotations.date.AutoNowDate
 import ir.amirroid.ktoradmin.annotations.defaultvalue.DefaultValueProvider

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/utils/Extensions.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/utils/Extensions.kt
@@ -46,6 +46,8 @@ internal fun ColumnSet.toSuitableStringForFile() =
     |    hasConfirmation = $hasConfirmation,
     |    valueMapper = ${valueMapper?.let { "\"${it}\"" }},
     |    preview = ${preview?.let { "\"${it}\"" }},
+    |    hasAutoComplete = $hasAutoComplete,
+    |    autoCompleteSearchFields = ${autoCompleteSearchFields.toSuitableStringForFile()},
     |)
 """.trimMargin("|")
 

--- a/KtorAdminLibrary/src/main/resources/static/css/autocomplete.css
+++ b/KtorAdminLibrary/src/main/resources/static/css/autocomplete.css
@@ -1,0 +1,288 @@
+.autocomplete-wrapper {
+    position: relative;
+    width: 100%;
+}
+
+/* Trigger element - looks like a select input */
+.autocomplete-trigger {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    height: 48px;
+    background-color: var(--background-gradient-start);
+    border-radius: 16px;
+    padding: 0 12px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    border: 2px solid transparent;
+}
+
+.autocomplete-trigger:hover {
+    border-color: var(--highlight-color);
+}
+
+.autocomplete-trigger:focus {
+    outline: none;
+    border-color: var(--secondary-color);
+}
+
+/* Selected value display */
+.autocomplete-selected {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--primary-color);
+    font-family: "Istok Web", serif;
+    font-weight: 400;
+    font-style: normal;
+    font-size: inherit;
+}
+
+.autocomplete-selected:not(.has-value) {
+    opacity: 0.5;
+}
+
+/* Clear button */
+.autocomplete-clear {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    margin-left: 8px;
+    border-radius: 50%;
+    background-color: var(--highlight-color);
+    color: var(--white);
+    font-size: 14px;
+    line-height: 1;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+    flex-shrink: 0;
+}
+
+.autocomplete-clear:hover {
+    background-color: var(--error-color);
+}
+
+/* Arrow icon */
+.autocomplete-arrow {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 8px;
+    color: var(--primary-color);
+    transition: transform 0.2s ease;
+    flex-shrink: 0;
+}
+
+.autocomplete-arrow.open {
+    transform: rotate(180deg);
+}
+
+/* Dropdown container - floating popup */
+.autocomplete-dropdown {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    right: 0;
+    background-color: var(--white, #ffffff);
+    border-radius: 12px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18), 0 2px 8px rgba(0, 0, 0, 0.08);
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    z-index: 1000;
+    overflow: hidden;
+    max-height: 400px;
+    display: flex;
+    flex-direction: column;
+    transform-origin: top center;
+}
+
+/* Search input container */
+.autocomplete-search-container {
+    padding: 12px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+    background-color: var(--white, #ffffff);
+}
+
+/* Search input */
+.autocomplete-search-input {
+    width: 100%;
+    height: 40px;
+    background-color: var(--background-gradient-start, #f5f5f5);
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    border-radius: 8px;
+    padding: 0 12px;
+    font-family: "Istok Web", serif;
+    font-weight: 400;
+    font-style: normal;
+    font-size: 14px;
+    color: var(--primary-color, #1a1a1a);
+    outline: none;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.autocomplete-search-input:focus {
+    border-color: var(--secondary-color, #1976d2);
+    box-shadow: 0 0 0 3px rgba(25, 118, 210, 0.12);
+}
+
+.autocomplete-search-input::placeholder {
+    color: var(--primary-color, #1a1a1a);
+    opacity: 0.4;
+}
+
+/* Results list */
+.autocomplete-list {
+    max-height: 320px;
+    overflow-y: auto;
+    scrollbar-width: thin;
+    padding: 4px 0;
+    background-color: var(--white, #ffffff);
+}
+
+.autocomplete-list::-webkit-scrollbar {
+    width: 6px;
+}
+
+.autocomplete-list::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.autocomplete-list::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 0, 0, 0.15);
+    border-radius: 3px;
+}
+
+/* Individual item */
+.autocomplete-item {
+    padding: 12px 16px;
+    cursor: pointer;
+    transition: background-color 0.1s ease;
+    color: var(--primary-color, #1a1a1a);
+    font-family: "Istok Web", serif;
+    font-weight: 400;
+    font-style: normal;
+    border-left: 3px solid transparent;
+    margin: 0 4px;
+    border-radius: 4px;
+}
+
+.autocomplete-item:hover,
+.autocomplete-item.highlighted {
+    background-color: rgba(25, 118, 210, 0.08);
+    border-left-color: var(--secondary-color, #1976d2);
+}
+
+.autocomplete-item.selected {
+    background-color: var(--secondary-color, #1976d2);
+    color: var(--white, #ffffff);
+    border-left-color: var(--secondary-color, #1976d2);
+}
+
+/* Empty state */
+.autocomplete-empty {
+    padding: 20px 16px;
+    color: var(--primary-color, #1a1a1a);
+    opacity: 0.5;
+    text-align: center;
+    font-style: italic;
+    font-size: 14px;
+}
+
+/* Error state */
+.autocomplete-error {
+    padding: 20px 16px;
+    color: var(--error-color, #e74c3c);
+    text-align: center;
+    font-size: 14px;
+}
+
+/* Loading state */
+.autocomplete-loading {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 16px;
+    color: var(--primary-color, #1a1a1a);
+    opacity: 0.7;
+    font-size: 14px;
+    background-color: var(--white, #ffffff);
+}
+
+.autocomplete-spinner {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    border: 2px solid rgba(0, 0, 0, 0.1);
+    border-top-color: var(--secondary-color, #1976d2);
+    border-radius: 50%;
+    animation: autocomplete-spin 0.8s linear infinite;
+}
+
+@keyframes autocomplete-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+/* Dark mode adjustments */
+:root.theme-dark .autocomplete-dropdown {
+    background-color: var(--background-gradient-start, #2a2a2a);
+    border-color: rgba(255, 255, 255, 0.1);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4), 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+:root.theme-dark .autocomplete-search-container {
+    background-color: var(--background-gradient-start, #2a2a2a);
+    border-bottom-color: rgba(255, 255, 255, 0.08);
+}
+
+:root.theme-dark .autocomplete-search-input {
+    background-color: var(--white-transparent-60, #3a3a3a);
+    border-color: rgba(255, 255, 255, 0.12);
+    color: var(--primary-color, #ffffff);
+}
+
+:root.theme-dark .autocomplete-search-input:focus {
+    border-color: var(--secondary-color, #64b5f6);
+    box-shadow: 0 0 0 3px rgba(100, 181, 246, 0.2);
+}
+
+:root.theme-dark .autocomplete-search-input::placeholder {
+    color: var(--primary-color, #ffffff);
+    opacity: 0.5;
+}
+
+:root.theme-dark .autocomplete-list {
+    background-color: var(--background-gradient-start, #2a2a2a);
+}
+
+:root.theme-dark .autocomplete-item {
+    color: var(--primary-color, #ffffff);
+}
+
+:root.theme-dark .autocomplete-item:hover,
+:root.theme-dark .autocomplete-item.highlighted {
+    background-color: rgba(100, 181, 246, 0.12);
+}
+
+:root.theme-dark .autocomplete-item.selected {
+    background-color: var(--secondary-color, #64b5f6);
+    color: var(--white, #ffffff);
+}
+
+:root.theme-dark .autocomplete-empty {
+    color: var(--primary-color, #ffffff);
+}
+
+:root.theme-dark .autocomplete-loading {
+    background-color: var(--background-gradient-start, #2a2a2a);
+    color: var(--primary-color, #ffffff);
+}
+
+:root.theme-dark .autocomplete-spinner {
+    border-color: rgba(255, 255, 255, 0.1);
+    border-top-color: var(--secondary-color, #64b5f6);
+}

--- a/KtorAdminLibrary/src/main/resources/static/js/autocomplete.js
+++ b/KtorAdminLibrary/src/main/resources/static/js/autocomplete.js
@@ -1,0 +1,444 @@
+class AutoComplete {
+    constructor(inputElement, config) {
+        this.input = inputElement;
+        this.config = {
+            tableName: config.tableName,
+            columnName: config.columnName,
+            debounceMs: config.debounceMs || 300,
+            adminPath: config.adminPath || 'admin',
+        };
+        this.selectedKey = null;
+        this.selectedLabel = '';
+        this.isOpen = false;
+        this.isLoading = false;
+        this.searchTimeout = null;
+        this.currentPage = 0;
+        this.hasMore = true;
+        this.items = [];
+        this.highlightedIndex = -1;
+
+        this.hiddenInput = this.input.parentNode.querySelector('input[type="hidden"]');
+        this.wrapper = null;
+        this.dropdown = null;
+        this.searchInput = null;
+        this.listElement = null;
+        this.loadingElement = null;
+
+        this.init();
+    }
+
+    init() {
+        this.createDropdown();
+        this.bindEvents();
+        this.loadInitialValue();
+    }
+
+    createDropdown() {
+        this.wrapper = document.createElement('div');
+        this.wrapper.className = 'autocomplete-wrapper';
+
+        this.trigger = document.createElement('div');
+        this.trigger.className = 'autocomplete-trigger';
+        this.trigger.setAttribute('tabindex', '0');
+        this.trigger.setAttribute('role', 'combobox');
+        this.trigger.setAttribute('aria-expanded', 'false');
+        this.trigger.setAttribute('aria-haspopup', 'listbox');
+
+        this.selectedDisplay = document.createElement('span');
+        this.selectedDisplay.className = 'autocomplete-selected';
+        this.selectedDisplay.textContent = this.input.value || '---';
+
+        this.clearButton = document.createElement('span');
+        this.clearButton.className = 'autocomplete-clear';
+        this.clearButton.innerHTML = '&times;';
+        this.clearButton.style.display = 'none';
+
+        this.arrowIcon = document.createElement('span');
+        this.arrowIcon.className = 'autocomplete-arrow';
+        this.arrowIcon.innerHTML = '<svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M2.5 4.5L6 8L9.5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+
+        this.trigger.appendChild(this.selectedDisplay);
+        this.trigger.appendChild(this.clearButton);
+        this.trigger.appendChild(this.arrowIcon);
+
+        this.dropdown = document.createElement('div');
+        this.dropdown.className = 'autocomplete-dropdown';
+        this.dropdown.style.display = 'none';
+        this.dropdown.setAttribute('role', 'listbox');
+
+        const searchContainer = document.createElement('div');
+        searchContainer.className = 'autocomplete-search-container';
+
+        this.searchInput = document.createElement('input');
+        this.searchInput.type = 'text';
+        this.searchInput.className = 'autocomplete-search-input';
+        this.searchInput.placeholder = 'Search...';
+        this.searchInput.setAttribute('autocomplete', 'off');
+
+        searchContainer.appendChild(this.searchInput);
+
+        this.listElement = document.createElement('div');
+        this.listElement.className = 'autocomplete-list';
+
+        this.loadingElement = document.createElement('div');
+        this.loadingElement.className = 'autocomplete-loading';
+        this.loadingElement.innerHTML = '<span class="autocomplete-spinner"></span> Loading...';
+
+        this.dropdown.appendChild(searchContainer);
+        this.dropdown.appendChild(this.listElement);
+        this.dropdown.appendChild(this.loadingElement);
+
+        this.input.parentNode.insertBefore(this.wrapper, this.input);
+        this.wrapper.appendChild(this.trigger);
+        this.wrapper.appendChild(this.dropdown);
+
+        this.input.style.display = 'none';
+    }
+
+    bindEvents() {
+        this.trigger.addEventListener('click', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (this.isOpen) {
+                this.hideDropdown();
+            } else {
+                this.showDropdown();
+            }
+        });
+
+        this.trigger.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                if (!this.isOpen) {
+                    this.showDropdown();
+                }
+            } else if (e.key === 'Escape') {
+                this.hideDropdown();
+            } else if (e.key === 'ArrowDown' && !this.isOpen) {
+                e.preventDefault();
+                this.showDropdown();
+            }
+        });
+
+        this.searchInput.addEventListener('input', () => {
+            this.currentPage = 0;
+            this.hasMore = true;
+            this.highlightedIndex = -1;
+            this.debouncedSearch();
+        });
+
+        this.searchInput.addEventListener('keydown', (e) => {
+            if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                this.highlightNext();
+            } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                this.highlightPrevious();
+            } else if (e.key === 'Enter') {
+                e.preventDefault();
+                if (this.highlightedIndex >= 0 && this.highlightedIndex < this.items.length) {
+                    this.selectItem(this.items[this.highlightedIndex]);
+                }
+            } else if (e.key === 'Escape') {
+                this.hideDropdown();
+            }
+        });
+
+        this.clearButton.addEventListener('click', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            this.clearSelection();
+        });
+
+        document.addEventListener('click', (e) => {
+            if (!this.wrapper.contains(e.target)) {
+                this.hideDropdown();
+            }
+        });
+
+        this.listElement.addEventListener('scroll', () => {
+            if (this.isLoading || !this.hasMore) return;
+            const { scrollTop, scrollHeight, clientHeight } = this.listElement;
+            if (scrollTop + clientHeight >= scrollHeight - 20) {
+                this.loadMore();
+            }
+        });
+    }
+
+    loadInitialValue() {
+        if (this.hiddenInput && this.hiddenInput.value) {
+            this.selectedKey = this.hiddenInput.value;
+            this.fetchItemLabel(this.hiddenInput.value);
+        }
+    }
+
+    async fetchItemLabel(key) {
+        try {
+            const response = await fetch(`/${this.config.adminPath}/autocomplete/${this.config.tableName}/${this.config.columnName}`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ search: '', page: 0 }),
+            });
+            if (!response.ok) throw new Error('Request failed');
+            const data = await response.json();
+            const item = data.items.find(i => i.key === key);
+            if (item) {
+                this.selectedLabel = item.label;
+                this.selectedDisplay.textContent = item.label;
+                this.selectedDisplay.classList.add('has-value');
+            }
+        } catch (error) {
+            console.error('Failed to fetch item label:', error);
+        }
+    }
+
+    getApiUrl() {
+        return `/${this.config.adminPath}/autocomplete/${this.config.tableName}/${this.config.columnName}`;
+    }
+
+    debouncedSearch() {
+        clearTimeout(this.searchTimeout);
+        this.searchTimeout = setTimeout(() => {
+            this.search();
+        }, this.config.debounceMs);
+    }
+
+    async search() {
+        if (this.isLoading) return;
+
+        const query = this.searchInput.value.trim();
+        this.isLoading = true;
+        this.showLoading();
+
+        try {
+            const response = await fetch(this.getApiUrl(), {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    search: query,
+                    page: 0,
+                }),
+            });
+
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+
+            const data = await response.json();
+            this.items = data.items;
+            this.hasMore = this.items.length < data.totalCount;
+            this.currentPage = 0;
+            this.highlightedIndex = -1;
+            this.renderItems();
+        } catch (error) {
+            console.error('Autocomplete search failed:', error);
+            this.showError('Failed to load results');
+        } finally {
+            this.isLoading = false;
+            this.hideLoading();
+        }
+    }
+
+    async loadMore() {
+        if (this.isLoading || !this.hasMore) return;
+
+        this.isLoading = true;
+        this.showLoading();
+
+        try {
+            const query = this.searchInput.value.trim();
+            const response = await fetch(this.getApiUrl(), {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    search: query,
+                    page: this.currentPage + 1,
+                }),
+            });
+
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+
+            const data = await response.json();
+            this.items = [...this.items, ...data.items];
+            this.hasMore = this.items.length < data.totalCount;
+            this.currentPage++;
+            this.renderItems();
+        } catch (error) {
+            console.error('Failed to load more items:', error);
+            this.showError('Failed to load more results');
+        } finally {
+            this.isLoading = false;
+            this.hideLoading();
+        }
+    }
+
+    renderItems() {
+        this.listElement.innerHTML = '';
+
+        if (this.items.length === 0) {
+            this.showEmpty();
+            return;
+        }
+
+        this.items.forEach((item, index) => {
+            const itemElement = document.createElement('div');
+            itemElement.className = 'autocomplete-item';
+            if (item.key === this.selectedKey) {
+                itemElement.classList.add('selected');
+            }
+            if (index === this.highlightedIndex) {
+                itemElement.classList.add('highlighted');
+            }
+            itemElement.textContent = item.label;
+            itemElement.dataset.index = index;
+            itemElement.setAttribute('role', 'option');
+            if (item.key === this.selectedKey) {
+                itemElement.setAttribute('aria-selected', 'true');
+            }
+
+            itemElement.addEventListener('click', (e) => {
+                e.preventDefault();
+                this.selectItem(item);
+            });
+
+            itemElement.addEventListener('mouseenter', () => {
+                this.highlightedIndex = index;
+                this.updateHighlight();
+            });
+
+            this.listElement.appendChild(itemElement);
+        });
+    }
+
+    showEmpty() {
+        this.listElement.innerHTML = '<div class="autocomplete-empty">No results found</div>';
+    }
+
+    showError(message) {
+        this.listElement.innerHTML = `<div class="autocomplete-error">${message}</div>`;
+    }
+
+    highlightNext() {
+        if (this.items.length === 0) return;
+        this.highlightedIndex = Math.min(this.highlightedIndex + 1, this.items.length - 1);
+        this.updateHighlight();
+        this.scrollToHighlighted();
+    }
+
+    highlightPrevious() {
+        if (this.items.length === 0) return;
+        this.highlightedIndex = Math.max(this.highlightedIndex - 1, 0);
+        this.updateHighlight();
+        this.scrollToHighlighted();
+    }
+
+    updateHighlight() {
+        const items = this.listElement.querySelectorAll('.autocomplete-item');
+        items.forEach((item, index) => {
+            if (index === this.highlightedIndex) {
+                item.classList.add('highlighted');
+            } else {
+                item.classList.remove('highlighted');
+            }
+        });
+    }
+
+    scrollToHighlighted() {
+        const highlighted = this.listElement.querySelector('.autocomplete-item.highlighted');
+        if (highlighted) {
+            highlighted.scrollIntoView({ block: 'nearest' });
+        }
+    }
+
+    selectItem(item) {
+        this.selectedKey = item.key;
+        this.selectedLabel = item.label;
+        this.selectedDisplay.textContent = item.label;
+        this.selectedDisplay.classList.add('has-value');
+        this.clearButton.style.display = 'flex';
+
+        if (this.hiddenInput) {
+            this.hiddenInput.value = item.key;
+        }
+
+        this.hideDropdown();
+        this.input.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+
+    clearSelection() {
+        this.selectedKey = null;
+        this.selectedLabel = '';
+        this.selectedDisplay.textContent = '---';
+        this.selectedDisplay.classList.remove('has-value');
+        this.clearButton.style.display = 'none';
+
+        if (this.hiddenInput) {
+            this.hiddenInput.value = '';
+        }
+
+        this.input.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+
+    showDropdown() {
+        this.dropdown.style.display = 'block';
+        this.isOpen = true;
+        this.trigger.setAttribute('aria-expanded', 'true');
+        this.arrowIcon.classList.add('open');
+        this.searchInput.value = '';
+        this.highlightedIndex = -1;
+
+        setTimeout(() => this.searchInput.focus(), 50);
+
+        // Load initial results
+        this.search();
+    }
+
+    hideDropdown() {
+        this.dropdown.style.display = 'none';
+        this.isOpen = false;
+        this.trigger.setAttribute('aria-expanded', 'false');
+        this.arrowIcon.classList.remove('open');
+    }
+
+    showLoading() {
+        this.loadingElement.style.display = 'flex';
+    }
+
+    hideLoading() {
+        this.loadingElement.style.display = 'none';
+    }
+
+    getValue() {
+        return this.selectedKey;
+    }
+
+    setValue(key, label) {
+        this.selectedKey = key;
+        this.selectedLabel = label;
+        this.selectedDisplay.textContent = label;
+        this.selectedDisplay.classList.add('has-value');
+        this.clearButton.style.display = 'flex';
+
+        if (this.hiddenInput) {
+            this.hiddenInput.value = key;
+        }
+    }
+}
+
+function initializeAutoCompletes() {
+    const autoCompleteInputs = document.querySelectorAll('[data-autocomplete]');
+    autoCompleteInputs.forEach(input => {
+        const config = {
+            tableName: input.dataset.autocompleteTable,
+            columnName: input.dataset.autocompleteColumn,
+            debounceMs: parseInt(input.dataset.autocompleteDebounce) || 300,
+            adminPath: input.dataset.autocompleteAdminPath || 'admin',
+        };
+
+        new AutoComplete(input, config);
+    });
+}
+
+document.addEventListener('DOMContentLoaded', initializeAutoCompletes);

--- a/KtorAdminLibrary/src/main/resources/templates/ktor_admin/admin_panel_upsert.vm
+++ b/KtorAdminLibrary/src/main/resources/templates/ktor_admin/admin_panel_upsert.vm
@@ -13,6 +13,7 @@
     #end
     <link href="/static/css/admin_panel_upsert.css" rel="stylesheet">
     <link href="/static/css/common_style.css" rel="stylesheet">
+    <link href="/static/css/autocomplete.css" rel="stylesheet">
     #if($tinyMCEConfig)
         <script src="https://cdnjs.cloudflare.com/ajax/libs/tinymce/6.7.1/tinymce.min.js"></script>
     #end
@@ -97,7 +98,15 @@
                         #end
                         #if($column.reference)
                             #set($referenceValues = $references.get($column))
-                            #if($column.reference.type == "select")
+                            #if($column.hasAutoComplete)
+                                <input type="hidden" name="$column.columnName" value="$!defaultValue" id="hidden-$column.columnName">
+                                <input type="text" class="form-input" value="$!defaultValue"
+                                       data-autocomplete data-autocomplete-table="$tableName"
+                                       data-autocomplete-column="$column.columnName"
+                                       data-autocomplete-admin-path="$adminPath"
+                                       #if($column.readOnly)readonly#end
+                                       placeholder="$translations['select_item']">
+                            #elseif($column.reference.type == "select")
                                 <div class="select-input-background">
                                     <select name="$column.columnName" class="select-input"
                                             #if($column.readOnly)disabled#end>
@@ -384,6 +393,7 @@
         #end
 </script>
 <script src="/static/js/common.js"></script>
+<script src="/static/js/autocomplete.js"></script>
 <script src="/static/js/upsert_admin.js"></script>
 </body>
 </html>

--- a/KtorAdminLibrary/src/test/kotlin/ir/amirroid/ktoradmin/models/AutoCompleteTest.kt
+++ b/KtorAdminLibrary/src/test/kotlin/ir/amirroid/ktoradmin/models/AutoCompleteTest.kt
@@ -1,0 +1,111 @@
+package ir.amirroid.ktoradmin.models
+
+import ir.amirroid.ktoradmin.models.common.Reference
+import ir.amirroid.ktoradmin.models.common.tableName
+import ir.amirroid.ktoradmin.models.types.ColumnType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AutoCompleteTest {
+
+    @Test
+    fun `ColumnSet hasAutoComplete defaults to false`() {
+        val column = ColumnSet(
+            columnName = "user_id",
+            verboseName = "User ID",
+            type = ColumnType.INTEGER,
+        )
+        assertFalse(column.hasAutoComplete)
+        assertTrue(column.autoCompleteSearchFields.isEmpty())
+    }
+
+    @Test
+    fun `ColumnSet can have hasAutoComplete set to true`() {
+        val column = ColumnSet(
+            columnName = "user_id",
+            verboseName = "User ID",
+            type = ColumnType.INTEGER,
+            hasAutoComplete = true,
+            reference = Reference.ManyToOne(
+                relatedTable = "users",
+                foreignKey = "id",
+            ),
+        )
+        assertTrue(column.hasAutoComplete)
+    }
+
+    @Test
+    fun `ColumnSet with reference and hasAutoComplete`() {
+        val column = ColumnSet(
+            columnName = "user_id",
+            verboseName = "Users",
+            type = ColumnType.INTEGER,
+            hasAutoComplete = true,
+            reference = Reference.ManyToOne(
+                relatedTable = "users",
+                foreignKey = "id",
+            ),
+        )
+        assertTrue(column.hasAutoComplete)
+        assertEquals("users", column.reference?.tableName)
+    }
+
+    @Test
+    fun `ColumnSet copy preserves hasAutoComplete`() {
+        val original = ColumnSet(
+            columnName = "user_id",
+            verboseName = "User ID",
+            type = ColumnType.INTEGER,
+            hasAutoComplete = true,
+            reference = Reference.ManyToOne(
+                relatedTable = "users",
+                foreignKey = "id",
+            ),
+        )
+        val copy = original.copy(columnName = "user_id_v2")
+        assertTrue(copy.hasAutoComplete)
+        assertEquals("user_id_v2", copy.columnName)
+    }
+
+    @Test
+    fun `ColumnSet with autoCompleteSearchFields`() {
+        val searchFields = listOf("username", "email", "id")
+        val column = ColumnSet(
+            columnName = "user_id",
+            verboseName = "Users",
+            type = ColumnType.INTEGER,
+            hasAutoComplete = true,
+            autoCompleteSearchFields = searchFields,
+            reference = Reference.ManyToOne(
+                relatedTable = "users",
+                foreignKey = "id",
+            ),
+        )
+        assertTrue(column.hasAutoComplete)
+        assertEquals(3, column.autoCompleteSearchFields.size)
+        assertEquals("username", column.autoCompleteSearchFields[0])
+        assertEquals("email", column.autoCompleteSearchFields[1])
+        assertEquals("id", column.autoCompleteSearchFields[2])
+    }
+
+    @Test
+    fun `ColumnSet with autoCompleteSearchFields preserves on copy`() {
+        val searchFields = listOf("username", "email")
+        val original = ColumnSet(
+            columnName = "user_id",
+            verboseName = "Users",
+            type = ColumnType.INTEGER,
+            hasAutoComplete = true,
+            autoCompleteSearchFields = searchFields,
+            reference = Reference.ManyToOne(
+                relatedTable = "users",
+                foreignKey = "id",
+            ),
+        )
+        val copy = original.copy(verboseName = "User")
+        assertEquals(2, copy.autoCompleteSearchFields.size)
+        assertEquals("username", copy.autoCompleteSearchFields[0])
+    }
+}

--- a/KtorAdminLibrary/src/test/kotlin/ir/amirroid/ktoradmin/models/AutoCompleteTest.kt
+++ b/KtorAdminLibrary/src/test/kotlin/ir/amirroid/ktoradmin/models/AutoCompleteTest.kt
@@ -9,61 +9,67 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class AutoCompleteTest {
-
     @Test
     fun `ColumnSet hasAutoComplete defaults to false`() {
-        val column = ColumnSet(
-            columnName = "user_id",
-            verboseName = "User ID",
-            type = ColumnType.INTEGER,
-        )
+        val column =
+            ColumnSet(
+                columnName = "user_id",
+                verboseName = "User ID",
+                type = ColumnType.INTEGER,
+            )
         assertFalse(column.hasAutoComplete)
         assertTrue(column.autoCompleteSearchFields.isEmpty())
     }
 
     @Test
     fun `ColumnSet can have hasAutoComplete set to true`() {
-        val column = ColumnSet(
-            columnName = "user_id",
-            verboseName = "User ID",
-            type = ColumnType.INTEGER,
-            hasAutoComplete = true,
-            reference = Reference.ManyToOne(
-                relatedTable = "users",
-                foreignKey = "id",
-            ),
-        )
+        val column =
+            ColumnSet(
+                columnName = "user_id",
+                verboseName = "User ID",
+                type = ColumnType.INTEGER,
+                hasAutoComplete = true,
+                reference =
+                    Reference.ManyToOne(
+                        relatedTable = "users",
+                        foreignKey = "id",
+                    ),
+            )
         assertTrue(column.hasAutoComplete)
     }
 
     @Test
     fun `ColumnSet with reference and hasAutoComplete`() {
-        val column = ColumnSet(
-            columnName = "user_id",
-            verboseName = "Users",
-            type = ColumnType.INTEGER,
-            hasAutoComplete = true,
-            reference = Reference.ManyToOne(
-                relatedTable = "users",
-                foreignKey = "id",
-            ),
-        )
+        val column =
+            ColumnSet(
+                columnName = "user_id",
+                verboseName = "Users",
+                type = ColumnType.INTEGER,
+                hasAutoComplete = true,
+                reference =
+                    Reference.ManyToOne(
+                        relatedTable = "users",
+                        foreignKey = "id",
+                    ),
+            )
         assertTrue(column.hasAutoComplete)
         assertEquals("users", column.reference?.tableName)
     }
 
     @Test
     fun `ColumnSet copy preserves hasAutoComplete`() {
-        val original = ColumnSet(
-            columnName = "user_id",
-            verboseName = "User ID",
-            type = ColumnType.INTEGER,
-            hasAutoComplete = true,
-            reference = Reference.ManyToOne(
-                relatedTable = "users",
-                foreignKey = "id",
-            ),
-        )
+        val original =
+            ColumnSet(
+                columnName = "user_id",
+                verboseName = "User ID",
+                type = ColumnType.INTEGER,
+                hasAutoComplete = true,
+                reference =
+                    Reference.ManyToOne(
+                        relatedTable = "users",
+                        foreignKey = "id",
+                    ),
+            )
         val copy = original.copy(columnName = "user_id_v2")
         assertTrue(copy.hasAutoComplete)
         assertEquals("user_id_v2", copy.columnName)
@@ -72,17 +78,19 @@ class AutoCompleteTest {
     @Test
     fun `ColumnSet with autoCompleteSearchFields`() {
         val searchFields = listOf("username", "email", "id")
-        val column = ColumnSet(
-            columnName = "user_id",
-            verboseName = "Users",
-            type = ColumnType.INTEGER,
-            hasAutoComplete = true,
-            autoCompleteSearchFields = searchFields,
-            reference = Reference.ManyToOne(
-                relatedTable = "users",
-                foreignKey = "id",
-            ),
-        )
+        val column =
+            ColumnSet(
+                columnName = "user_id",
+                verboseName = "Users",
+                type = ColumnType.INTEGER,
+                hasAutoComplete = true,
+                autoCompleteSearchFields = searchFields,
+                reference =
+                    Reference.ManyToOne(
+                        relatedTable = "users",
+                        foreignKey = "id",
+                    ),
+            )
         assertTrue(column.hasAutoComplete)
         assertEquals(3, column.autoCompleteSearchFields.size)
         assertEquals("username", column.autoCompleteSearchFields[0])
@@ -93,17 +101,19 @@ class AutoCompleteTest {
     @Test
     fun `ColumnSet with autoCompleteSearchFields preserves on copy`() {
         val searchFields = listOf("username", "email")
-        val original = ColumnSet(
-            columnName = "user_id",
-            verboseName = "Users",
-            type = ColumnType.INTEGER,
-            hasAutoComplete = true,
-            autoCompleteSearchFields = searchFields,
-            reference = Reference.ManyToOne(
-                relatedTable = "users",
-                foreignKey = "id",
-            ),
-        )
+        val original =
+            ColumnSet(
+                columnName = "user_id",
+                verboseName = "Users",
+                type = ColumnType.INTEGER,
+                hasAutoComplete = true,
+                autoCompleteSearchFields = searchFields,
+                reference =
+                    Reference.ManyToOne(
+                        relatedTable = "users",
+                        foreignKey = "id",
+                    ),
+            )
         val copy = original.copy(verboseName = "User")
         assertEquals(2, copy.autoCompleteSearchFields.size)
         assertEquals("username", copy.autoCompleteSearchFields[0])

--- a/KtorAdminLibrary/src/test/kotlin/ir/amirroid/ktoradmin/modules/autocomplete/AutoCompleteModelsTest.kt
+++ b/KtorAdminLibrary/src/test/kotlin/ir/amirroid/ktoradmin/modules/autocomplete/AutoCompleteModelsTest.kt
@@ -1,0 +1,61 @@
+package ir.amirroid.ktoradmin.modules.autocomplete
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AutoCompleteModelsTest {
+
+    @Test
+    fun `AutoCompleteRequest defaults`() {
+        val request = AutoCompleteRequest()
+        assertEquals("", request.search)
+        assertEquals(0, request.page)
+    }
+
+    @Test
+    fun `AutoCompleteRequest custom values`() {
+        val request = AutoCompleteRequest(
+            search = "test",
+            page = 2,
+        )
+        assertEquals("test", request.search)
+        assertEquals(2, request.page)
+    }
+
+    @Test
+    fun `AutoCompleteItem creation`() {
+        val item = AutoCompleteItem(
+            key = "1",
+            label = "Test User",
+        )
+        assertEquals("1", item.key)
+        assertEquals("Test User", item.label)
+    }
+
+    @Test
+    fun `AutoCompleteResponse creation`() {
+        val items = listOf(
+            AutoCompleteItem("1", "User 1"),
+            AutoCompleteItem("2", "User 2"),
+        )
+        val response = AutoCompleteResponse(
+            items = items,
+            totalCount = 2,
+        )
+        assertEquals(2, response.items.size)
+        assertEquals(2, response.totalCount)
+        assertEquals("1", response.items[0].key)
+        assertEquals("User 2", response.items[1].label)
+    }
+
+    @Test
+    fun `AutoCompleteResponse empty items`() {
+        val response = AutoCompleteResponse(
+            items = emptyList(),
+            totalCount = 0,
+        )
+        assertTrue(response.items.isEmpty())
+        assertEquals(0, response.totalCount)
+    }
+}

--- a/KtorAdminLibrary/src/test/kotlin/ir/amirroid/ktoradmin/modules/autocomplete/AutoCompleteModelsTest.kt
+++ b/KtorAdminLibrary/src/test/kotlin/ir/amirroid/ktoradmin/modules/autocomplete/AutoCompleteModelsTest.kt
@@ -5,7 +5,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class AutoCompleteModelsTest {
-
     @Test
     fun `AutoCompleteRequest defaults`() {
         val request = AutoCompleteRequest()
@@ -15,34 +14,38 @@ class AutoCompleteModelsTest {
 
     @Test
     fun `AutoCompleteRequest custom values`() {
-        val request = AutoCompleteRequest(
-            search = "test",
-            page = 2,
-        )
+        val request =
+            AutoCompleteRequest(
+                search = "test",
+                page = 2,
+            )
         assertEquals("test", request.search)
         assertEquals(2, request.page)
     }
 
     @Test
     fun `AutoCompleteItem creation`() {
-        val item = AutoCompleteItem(
-            key = "1",
-            label = "Test User",
-        )
+        val item =
+            AutoCompleteItem(
+                key = "1",
+                label = "Test User",
+            )
         assertEquals("1", item.key)
         assertEquals("Test User", item.label)
     }
 
     @Test
     fun `AutoCompleteResponse creation`() {
-        val items = listOf(
-            AutoCompleteItem("1", "User 1"),
-            AutoCompleteItem("2", "User 2"),
-        )
-        val response = AutoCompleteResponse(
-            items = items,
-            totalCount = 2,
-        )
+        val items =
+            listOf(
+                AutoCompleteItem("1", "User 1"),
+                AutoCompleteItem("2", "User 2"),
+            )
+        val response =
+            AutoCompleteResponse(
+                items = items,
+                totalCount = 2,
+            )
         assertEquals(2, response.items.size)
         assertEquals(2, response.totalCount)
         assertEquals("1", response.items[0].key)
@@ -51,10 +54,11 @@ class AutoCompleteModelsTest {
 
     @Test
     fun `AutoCompleteResponse empty items`() {
-        val response = AutoCompleteResponse(
-            items = emptyList(),
-            totalCount = 0,
-        )
+        val response =
+            AutoCompleteResponse(
+                items = emptyList(),
+                totalCount = 0,
+            )
         assertTrue(response.items.isEmpty())
         assertEquals(0, response.totalCount)
     }

--- a/src/main/kotlin/ir/amirreza/Admin.kt
+++ b/src/main/kotlin/ir/amirreza/Admin.kt
@@ -64,6 +64,7 @@ fun Application.configureAdmin(database: Database) {
         registerDefaultValueProvider(UUIDDefaultValueProvider())
         registerPreview(VideoPreview())
         registerPreview(ImagePreview())
+        autoCompletePageSize = 10
         registerValueMapper(
             CustomValueMapper2
         )

--- a/src/main/kotlin/ir/amirreza/Tasks.kt
+++ b/src/main/kotlin/ir/amirreza/Tasks.kt
@@ -1,5 +1,6 @@
 package ir.amirreza
 
+import ir.amirroid.ktoradmin.annotations.autocomplete.AutoComplete
 import ir.amirroid.ktoradmin.annotations.computed.Computed
 import ir.amirroid.ktoradmin.annotations.date.AutoNowDate
 import ir.amirroid.ktoradmin.annotations.display.PanelDisplayList
@@ -80,11 +81,11 @@ object Tasks : Table("tasks") {
 
     @ColumnInfo("user_id", verboseName = "Users")
     @ManyToOneReferences("users", "id")
+    @AutoComplete(searchFields = ["username"])
     val userId = integer("user_id").references(Users.id)
 
     @ManyToManyReferences("users", "tasks_users", "task_id", "user_id")
     val users = EmptyColumn()
-
 
     @ColumnInfo(
         unique = true


### PR DESCRIPTION
- Add `@AutoComplete` annotation to enable searchable dropdowns for foreign key relationships.
- Implement `AutoCompleteController` and routing to handle asynchronous search requests.
- Add `JdbcQueriesRepository` logic to perform paginated searches against referenced tables.
- Create frontend `autocomplete.js` and `autocomplete.css` for the UI component.
- Update the upsert template to integrate the autocomplete input for annotated columns.
- Add configuration for `autoCompletePageSize` in `KtorAdminConfiguration`.