### PR TITLE
feat: Add extensible audit logging architecture

### DIFF
--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/audit/AuditEventListener.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/audit/AuditEventListener.kt
@@ -1,0 +1,147 @@
+package ir.amirroid.ktoradmin.audit
+
+import ir.amirroid.ktoradmin.listener.AdminEventListener
+import ir.amirroid.ktoradmin.models.events.ColumnEvent
+import ir.amirroid.ktoradmin.models.events.FieldEvent
+
+class AuditEventListener(
+    private val logger: AuditLogger,
+    private val enrich: (AuditEvent) -> AuditEvent = { it },
+) : AdminEventListener() {
+    override suspend fun onInsertJdbcData(
+        tableName: String,
+        objectPrimaryKey: String,
+        events: List<ColumnEvent>,
+    ) {
+        logger.log(
+            buildMutationEvent(
+                action = AuditAction.INSERT,
+                resourceType = AuditResourceType.JDBC_TABLE,
+                resourceName = tableName,
+                objectPrimaryKey = objectPrimaryKey,
+                changes = events.map { it.toAuditFieldChange() },
+            ),
+        )
+    }
+
+    override suspend fun onInsertMongoData(
+        collectionName: String,
+        objectPrimaryKey: String,
+        events: List<FieldEvent>,
+    ) {
+        logger.log(
+            buildMutationEvent(
+                action = AuditAction.INSERT,
+                resourceType = AuditResourceType.MONGO_COLLECTION,
+                resourceName = collectionName,
+                objectPrimaryKey = objectPrimaryKey,
+                changes = events.map { it.toAuditFieldChange() },
+            ),
+        )
+    }
+
+    override suspend fun onUpdateJdbcData(
+        tableName: String,
+        objectPrimaryKey: String,
+        events: List<ColumnEvent>,
+    ) {
+        logger.log(
+            buildMutationEvent(
+                action = AuditAction.UPDATE,
+                resourceType = AuditResourceType.JDBC_TABLE,
+                resourceName = tableName,
+                objectPrimaryKey = objectPrimaryKey,
+                changes = events.map { it.toAuditFieldChange() },
+            ),
+        )
+    }
+
+    override suspend fun onUpdateMongoData(
+        collectionName: String,
+        objectPrimaryKey: String,
+        events: List<FieldEvent>,
+    ) {
+        logger.log(
+            buildMutationEvent(
+                action = AuditAction.UPDATE,
+                resourceType = AuditResourceType.MONGO_COLLECTION,
+                resourceName = collectionName,
+                objectPrimaryKey = objectPrimaryKey,
+                changes = events.map { it.toAuditFieldChange() },
+            ),
+        )
+    }
+
+    override suspend fun onDeleteJdbcObjects(
+        tableName: String,
+        objectPrimaryKeys: List<String>,
+    ) {
+        logger.log(
+            buildDeleteEvent(
+                resourceType = AuditResourceType.JDBC_TABLE,
+                resourceName = tableName,
+                objectPrimaryKeys = objectPrimaryKeys,
+            ),
+        )
+    }
+
+    override suspend fun onDeleteMongoObjects(
+        collectionName: String,
+        objectPrimaryKeys: List<String>,
+    ) {
+        logger.log(
+            buildDeleteEvent(
+                resourceType = AuditResourceType.MONGO_COLLECTION,
+                resourceName = collectionName,
+                objectPrimaryKeys = objectPrimaryKeys,
+            ),
+        )
+    }
+
+    private fun buildMutationEvent(
+        action: AuditAction,
+        resourceType: AuditResourceType,
+        resourceName: String,
+        objectPrimaryKey: String,
+        changes: List<AuditFieldChange>,
+    ): AuditEvent =
+        enrich(
+            AuditEvent(
+                action = action,
+                resourceType = resourceType,
+                resourceName = resourceName,
+                objectPrimaryKeys = listOf(objectPrimaryKey),
+                changes = changes,
+            ),
+        )
+
+    private fun buildDeleteEvent(
+        resourceType: AuditResourceType,
+        resourceName: String,
+        objectPrimaryKeys: List<String>,
+    ): AuditEvent =
+        enrich(
+            AuditEvent(
+                action = AuditAction.DELETE,
+                resourceType = resourceType,
+                resourceName = resourceName,
+                objectPrimaryKeys = objectPrimaryKeys,
+            ),
+        )
+
+    private fun ColumnEvent.toAuditFieldChange(): AuditFieldChange =
+        AuditFieldChange(
+            name = columnSet.columnName,
+            verboseName = columnSet.verboseName,
+            changed = changed,
+            value = value,
+        )
+
+    private fun FieldEvent.toAuditFieldChange(): AuditFieldChange =
+        AuditFieldChange(
+            name = fieldSet.fieldName.orEmpty(),
+            verboseName = fieldSet.verboseName,
+            changed = changed,
+            value = value,
+        )
+}

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/audit/AuditFormatters.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/audit/AuditFormatters.kt
@@ -1,0 +1,27 @@
+package ir.amirroid.ktoradmin.audit
+
+object AuditFormatters {
+    val event: AuditFormatter<AuditEvent> = AuditFormatter { it }
+
+    val map: AuditFormatter<Map<String, Any?>> =
+        AuditFormatter { event ->
+            mapOf(
+                "id" to event.id,
+                "occurredAt" to event.occurredAt.toString(),
+                "action" to event.action.name,
+                "resourceType" to event.resourceType.name,
+                "resourceName" to event.resourceName,
+                "objectPrimaryKeys" to event.objectPrimaryKeys,
+                "changes" to
+                    event.changes.map { change ->
+                        mapOf(
+                            "name" to change.name,
+                            "verboseName" to change.verboseName,
+                            "changed" to change.changed,
+                            "value" to change.value,
+                        )
+                    },
+                "attributes" to event.attributes,
+            )
+        }
+}

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/audit/AuditHandler.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/audit/AuditHandler.kt
@@ -1,0 +1,32 @@
+package ir.amirroid.ktoradmin.audit
+
+fun interface AuditFormatter<out T> {
+    suspend fun format(event: AuditEvent): T
+}
+
+fun interface AuditDestination<in T> {
+    suspend fun write(
+        payload: T,
+        event: AuditEvent,
+    )
+}
+
+interface AuditExecutionHandler {
+    val key: String
+
+    suspend fun handle(event: AuditEvent)
+}
+
+class FormattingAuditExecutionHandler<T>(
+    override val key: String,
+    private val formatter: AuditFormatter<T>,
+    private val destination: AuditDestination<T>,
+) : AuditExecutionHandler {
+    override suspend fun handle(event: AuditEvent) {
+        destination.write(formatter.format(event), event)
+    }
+}
+
+fun interface AuditErrorHandler {
+    fun onFailure(result: AuditDispatchResult)
+}

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/audit/AuditLogger.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/audit/AuditLogger.kt
@@ -1,0 +1,71 @@
+package ir.amirroid.ktoradmin.audit
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import java.util.concurrent.ConcurrentHashMap
+
+class AuditLogger(
+    private val failOnHandlerError: Boolean = false,
+    private val errorHandler: AuditErrorHandler? = null,
+) {
+    private val handlers = ConcurrentHashMap<String, AuditExecutionHandler>()
+
+    val registeredHandlerKeys: Set<String>
+        get() = handlers.keys.toSet()
+
+    fun registerHandler(handler: AuditExecutionHandler): AuditLogger {
+        require(handler.key.isNotBlank()) { "Audit handler key cannot be blank." }
+        val previous = handlers.putIfAbsent(handler.key, handler)
+        require(previous == null) { "An audit handler with key '${handler.key}' is already registered." }
+        return this
+    }
+
+    fun <T> registerDestination(
+        key: String,
+        formatter: AuditFormatter<T>,
+        destination: AuditDestination<T>,
+    ): AuditLogger =
+        registerHandler(
+            FormattingAuditExecutionHandler(
+                key = key,
+                formatter = formatter,
+                destination = destination,
+            ),
+        )
+
+    fun unregisterHandler(key: String): Boolean = handlers.remove(key) != null
+
+    suspend fun log(event: AuditEvent): AuditDispatchResult {
+        val activeHandlers = handlers.values.toList()
+        val failures =
+            coroutineScope {
+                activeHandlers
+                    .map { handler ->
+                        async {
+                            val exception = runCatching { handler.handle(event) }.exceptionOrNull()
+                            if (exception is CancellationException) throw exception
+                            exception?.let { AuditDispatchFailure(handler.key, it) }
+                        }
+                    }.awaitAll()
+                    .filterNotNull()
+            }
+
+        val result = AuditDispatchResult(event, failures)
+        if (!result.isSuccess) {
+            errorHandler?.onFailure(result)
+            if (failOnHandlerError) {
+                throw AuditLogException(result)
+            }
+        }
+        return result
+    }
+}
+
+class AuditLogException(
+    val result: AuditDispatchResult,
+) : RuntimeException(
+        "Audit log dispatch failed for handlers: ${result.failures.joinToString { it.handlerKey }}",
+        result.failures.firstOrNull()?.cause,
+    )

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/audit/AuditModels.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/audit/AuditModels.kt
@@ -1,0 +1,49 @@
+package ir.amirroid.ktoradmin.audit
+
+import java.time.Instant
+import java.util.UUID
+
+enum class AuditAction {
+    INSERT,
+    UPDATE,
+    DELETE,
+}
+
+enum class AuditResourceType {
+    JDBC_TABLE,
+    MONGO_COLLECTION,
+}
+
+data class AuditFieldChange(
+    val name: String,
+    val verboseName: String = name,
+    val changed: Boolean,
+    val value: Any?,
+)
+
+data class AuditEvent(
+    val id: String = UUID.randomUUID().toString(),
+    val occurredAt: Instant = Instant.now(),
+    val action: AuditAction,
+    val resourceType: AuditResourceType,
+    val resourceName: String,
+    val objectPrimaryKeys: List<String>,
+    val changes: List<AuditFieldChange> = emptyList(),
+    val attributes: Map<String, Any?> = emptyMap(),
+) {
+    val objectPrimaryKey: String?
+        get() = objectPrimaryKeys.firstOrNull()
+}
+
+data class AuditDispatchFailure(
+    val handlerKey: String,
+    val cause: Throwable,
+)
+
+data class AuditDispatchResult(
+    val event: AuditEvent,
+    val failures: List<AuditDispatchFailure>,
+) {
+    val isSuccess: Boolean
+        get() = failures.isEmpty()
+}

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/configuration/DynamicConfiguration.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/configuration/DynamicConfiguration.kt
@@ -3,6 +3,7 @@ package ir.amirroid.ktoradmin.configuration
 import ir.amirroid.ktoradmin.action.CustomAdminAction
 import ir.amirroid.ktoradmin.dashboard.KtorAdminDashboard
 import ir.amirroid.ktoradmin.listener.AdminEventListener
+import ir.amirroid.ktoradmin.listener.CompositeAdminEventListener
 import ir.amirroid.ktoradmin.mapper.KtorAdminValueMapper
 import ir.amirroid.ktoradmin.models.FileDeleteStrategy
 import ir.amirroid.ktoradmin.models.forms.LoginFiled
@@ -52,8 +53,24 @@ internal object DynamicConfiguration {
     var currentEventListener: AdminEventListener?
         get() = _currentEventListener.get()
         set(value) {
-            if (!_currentEventListener.compareAndSet(null, value)) {
-                throw IllegalStateException("An event listener is already registered. Please unregister it before registering a new one.")
+            value ?: run {
+                _currentEventListener.set(null)
+                return
+            }
+
+            while (true) {
+                val current = _currentEventListener.get()
+                when (current) {
+                    null -> if (_currentEventListener.compareAndSet(null, value)) return
+                    is CompositeAdminEventListener -> {
+                        current.add(value)
+                        return
+                    }
+                    else -> {
+                        val composite = CompositeAdminEventListener(listOf(current, value))
+                        if (_currentEventListener.compareAndSet(current, composite)) return
+                    }
+                }
             }
         }
 

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/configuration/KtorAdminConfiguration.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/configuration/KtorAdminConfiguration.kt
@@ -3,6 +3,13 @@ package ir.amirroid.ktoradmin.configuration
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import ir.amirroid.ktoradmin.action.CustomAdminAction
+import ir.amirroid.ktoradmin.audit.AuditDestination
+import ir.amirroid.ktoradmin.audit.AuditErrorHandler
+import ir.amirroid.ktoradmin.audit.AuditEventListener
+import ir.amirroid.ktoradmin.audit.AuditExecutionHandler
+import ir.amirroid.ktoradmin.audit.AuditFormatter
+import ir.amirroid.ktoradmin.audit.AuditLogger
+import ir.amirroid.ktoradmin.audit.FormattingAuditExecutionHandler
 import ir.amirroid.ktoradmin.csrf.CsrfManager
 import ir.amirroid.ktoradmin.dashboard.KtorAdminDashboard
 import ir.amirroid.ktoradmin.hikra.KtorAdminHikariCP
@@ -326,6 +333,22 @@ class KtorAdminConfiguration {
     }
 
     /**
+     * Registers a built-in audit logger as an admin event listener.
+     */
+    fun registerAuditLogger(logger: AuditLogger) {
+        registerEventListener(AuditEventListener(logger))
+    }
+
+    /**
+     * Configures and registers a built-in audit logger.
+     */
+    fun audit(configure: AuditLoggerBuilder.() -> Unit): AuditLogger {
+        val logger = AuditLoggerBuilder().apply(configure).build()
+        registerAuditLogger(logger)
+        return logger
+    }
+
+    /**
      * Registers a new preview.
      */
     fun registerPreview(preview: KtorAdminPreview) {
@@ -358,4 +381,37 @@ class KtorAdminConfiguration {
         KtorAdminHikariCP.closeAllConnections()
         MongoClientRepository.closeAllConnections()
     }
+}
+
+class AuditLoggerBuilder {
+    var failOnHandlerError: Boolean = false
+    var errorHandler: AuditErrorHandler? = null
+
+    private val handlers = mutableListOf<AuditExecutionHandler>()
+
+    fun registerHandler(handler: AuditExecutionHandler) {
+        handlers.add(handler)
+    }
+
+    fun <T> registerDestination(
+        key: String,
+        formatter: AuditFormatter<T>,
+        destination: AuditDestination<T>,
+    ) {
+        registerHandler(
+            FormattingAuditExecutionHandler(
+                key = key,
+                formatter = formatter,
+                destination = destination,
+            ),
+        )
+    }
+
+    fun build(): AuditLogger =
+        AuditLogger(
+            failOnHandlerError = failOnHandlerError,
+            errorHandler = errorHandler,
+        ).also { logger ->
+            handlers.forEach(logger::registerHandler)
+        }
 }

--- a/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/listener/CompositeAdminEventListener.kt
+++ b/KtorAdminLibrary/src/main/kotlin/ir/amirroid/ktoradmin/listener/CompositeAdminEventListener.kt
@@ -1,0 +1,61 @@
+package ir.amirroid.ktoradmin.listener
+
+import ir.amirroid.ktoradmin.models.events.ColumnEvent
+import ir.amirroid.ktoradmin.models.events.FieldEvent
+import java.util.concurrent.CopyOnWriteArrayList
+
+internal class CompositeAdminEventListener(
+    listeners: Collection<AdminEventListener> = emptyList(),
+) : AdminEventListener() {
+    private val listeners = CopyOnWriteArrayList(listeners)
+
+    fun add(listener: AdminEventListener) {
+        listeners.add(listener)
+    }
+
+    override suspend fun onInsertJdbcData(
+        tableName: String,
+        objectPrimaryKey: String,
+        events: List<ColumnEvent>,
+    ) {
+        listeners.forEach { it.onInsertJdbcData(tableName, objectPrimaryKey, events) }
+    }
+
+    override suspend fun onInsertMongoData(
+        collectionName: String,
+        objectPrimaryKey: String,
+        events: List<FieldEvent>,
+    ) {
+        listeners.forEach { it.onInsertMongoData(collectionName, objectPrimaryKey, events) }
+    }
+
+    override suspend fun onUpdateJdbcData(
+        tableName: String,
+        objectPrimaryKey: String,
+        events: List<ColumnEvent>,
+    ) {
+        listeners.forEach { it.onUpdateJdbcData(tableName, objectPrimaryKey, events) }
+    }
+
+    override suspend fun onUpdateMongoData(
+        collectionName: String,
+        objectPrimaryKey: String,
+        events: List<FieldEvent>,
+    ) {
+        listeners.forEach { it.onUpdateMongoData(collectionName, objectPrimaryKey, events) }
+    }
+
+    override suspend fun onDeleteJdbcObjects(
+        tableName: String,
+        objectPrimaryKeys: List<String>,
+    ) {
+        listeners.forEach { it.onDeleteJdbcObjects(tableName, objectPrimaryKeys) }
+    }
+
+    override suspend fun onDeleteMongoObjects(
+        collectionName: String,
+        objectPrimaryKeys: List<String>,
+    ) {
+        listeners.forEach { it.onDeleteMongoObjects(collectionName, objectPrimaryKeys) }
+    }
+}

--- a/KtorAdminLibrary/src/test/kotlin/ir/amirroid/ktoradmin/audit/AuditEventListenerTest.kt
+++ b/KtorAdminLibrary/src/test/kotlin/ir/amirroid/ktoradmin/audit/AuditEventListenerTest.kt
@@ -1,0 +1,72 @@
+package ir.amirroid.ktoradmin.audit
+
+import ir.amirroid.ktoradmin.column
+import ir.amirroid.ktoradmin.models.events.ColumnEvent
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AuditEventListenerTest {
+    @Test
+    fun `should convert jdbc insert callback to normalized audit event`() =
+        runBlocking {
+            val events = mutableListOf<AuditEvent>()
+            val logger =
+                AuditLogger()
+                    .registerDestination(
+                        key = "memory",
+                        formatter = AuditFormatters.event,
+                        destination = AuditDestination { payload, _ -> events.add(payload) },
+                    )
+            val listener =
+                AuditEventListener(logger) {
+                    it.copy(attributes = it.attributes + ("actorId" to "admin-1"))
+                }
+
+            listener.onInsertJdbcData(
+                tableName = "users",
+                objectPrimaryKey = "7",
+                events =
+                    listOf(
+                        ColumnEvent(
+                            changed = true,
+                            columnSet = column("email"),
+                            value = "ada@example.com",
+                        ),
+                    ),
+            )
+
+            assertEquals(1, events.size)
+            val event = events.single()
+            assertEquals(AuditAction.INSERT, event.action)
+            assertEquals(AuditResourceType.JDBC_TABLE, event.resourceType)
+            assertEquals("users", event.resourceName)
+            assertEquals(listOf("7"), event.objectPrimaryKeys)
+            assertEquals("email", event.changes.single().name)
+            assertEquals("ada@example.com", event.changes.single().value)
+            assertEquals("admin-1", event.attributes["actorId"])
+        }
+
+    @Test
+    fun `should convert delete callbacks to audit event without changes`() =
+        runBlocking {
+            val events = mutableListOf<AuditEvent>()
+            val logger =
+                AuditLogger()
+                    .registerDestination(
+                        key = "memory",
+                        formatter = AuditFormatters.event,
+                        destination = AuditDestination { payload, _ -> events.add(payload) },
+                    )
+            val listener = AuditEventListener(logger)
+
+            listener.onDeleteMongoObjects("posts", listOf("a", "b"))
+
+            val event = events.single()
+            assertEquals(AuditAction.DELETE, event.action)
+            assertEquals(AuditResourceType.MONGO_COLLECTION, event.resourceType)
+            assertEquals("posts", event.resourceName)
+            assertEquals(listOf("a", "b"), event.objectPrimaryKeys)
+            assertEquals(emptyList(), event.changes)
+        }
+}

--- a/KtorAdminLibrary/src/test/kotlin/ir/amirroid/ktoradmin/audit/AuditLoggerTest.kt
+++ b/KtorAdminLibrary/src/test/kotlin/ir/amirroid/ktoradmin/audit/AuditLoggerTest.kt
@@ -1,0 +1,135 @@
+package ir.amirroid.ktoradmin.audit
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.system.measureTimeMillis
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AuditLoggerTest {
+    @Test
+    fun `should format event and write to multiple destinations concurrently`() =
+        runBlocking {
+            val writes = CopyOnWriteArrayList<Map<String, Any?>>()
+            val logger = AuditLogger()
+            logger.registerDestination(
+                key = "primary",
+                formatter = AuditFormatters.map,
+                destination =
+                    AuditDestination { payload, _ ->
+                        delay(100)
+                        writes.add(payload)
+                    },
+            )
+            logger.registerDestination(
+                key = "replica",
+                formatter = AuditFormatters.map,
+                destination =
+                    AuditDestination { payload, _ ->
+                        delay(100)
+                        writes.add(payload)
+                    },
+            )
+
+            val elapsed =
+                measureTimeMillis {
+                    val result = logger.log(testEvent())
+                    assertTrue(result.isSuccess)
+                }
+
+            assertEquals(2, writes.size)
+            assertTrue(elapsed < 180, "Handlers should run concurrently, elapsed=$elapsed ms")
+            assertEquals(setOf("primary", "replica"), logger.registeredHandlerKeys)
+        }
+
+    @Test
+    fun `should collect handler failures without blocking successful handlers`() =
+        runBlocking {
+            var successfulHandlerCalled = false
+            val failures = mutableListOf<AuditDispatchResult>()
+            val logger =
+                AuditLogger(
+                    errorHandler = AuditErrorHandler { failures.add(it) },
+                )
+            logger.registerHandler(
+                object : AuditExecutionHandler {
+                    override val key: String = "failing"
+
+                    override suspend fun handle(event: AuditEvent) {
+                        error("Destination unavailable")
+                    }
+                },
+            )
+            logger.registerHandler(
+                object : AuditExecutionHandler {
+                    override val key: String = "successful"
+
+                    override suspend fun handle(event: AuditEvent) {
+                        successfulHandlerCalled = true
+                    }
+                },
+            )
+
+            val result = logger.log(testEvent())
+
+            assertFalse(result.isSuccess)
+            assertTrue(successfulHandlerCalled)
+            assertEquals(listOf("failing"), result.failures.map { it.handlerKey })
+            assertEquals(1, failures.size)
+        }
+
+    @Test
+    fun `should throw when fail on handler error is enabled`() =
+        runBlocking {
+            val logger =
+                AuditLogger(failOnHandlerError = true)
+                    .registerHandler(
+                        object : AuditExecutionHandler {
+                            override val key: String = "failing"
+
+                            override suspend fun handle(event: AuditEvent) {
+                                error("Destination unavailable")
+                            }
+                        },
+                    )
+
+            val exception = assertFailsWith<AuditLogException> { logger.log(testEvent()) }
+            assertEquals(listOf("failing"), exception.result.failures.map { it.handlerKey })
+        }
+
+    @Test
+    fun `should support runtime handler removal`() =
+        runBlocking {
+            var calls = 0
+            val logger =
+                AuditLogger()
+                    .registerHandler(
+                        object : AuditExecutionHandler {
+                            override val key: String = "runtime"
+
+                            override suspend fun handle(event: AuditEvent) {
+                                calls++
+                            }
+                        },
+                    )
+
+            assertTrue(logger.unregisterHandler("runtime"))
+            assertFalse(logger.unregisterHandler("runtime"))
+            logger.log(testEvent())
+
+            assertEquals(0, calls)
+        }
+
+    private fun testEvent(): AuditEvent =
+        AuditEvent(
+            action = AuditAction.UPDATE,
+            resourceType = AuditResourceType.JDBC_TABLE,
+            resourceName = "users",
+            objectPrimaryKeys = listOf("1"),
+            changes = listOf(AuditFieldChange("name", changed = true, value = "Ada")),
+        )
+}

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -31,6 +31,7 @@
 * [Enumeration](features/enumeration.md)
 * [Rich Editor](features/rich-editor.md)
 * [AutoNowDate](features/autonowdate.md)
+* [Self-Adaptive Audit Log](features/audit-log.md)
 * [Additional Features](features/additional-features.md)
 
 ## Security

--- a/docs/features/audit-log.md
+++ b/docs/features/audit-log.md
@@ -1,0 +1,187 @@
+---
+description: Extensible audit logging in KtorAdmin
+---
+
+# Audit Log
+
+KtorAdmin includes a built-in audit log architecture that converts admin data events into normalized `AuditEvent` objects and dispatches them to any number of destinations. The logger separates log generation from log consumption:
+
+* `AuditEventListener` listens to KtorAdmin insert, update, and delete callbacks.
+* `AuditLogger` dispatches each normalized event to registered handlers concurrently.
+* `AuditFormatter<T>` converts an `AuditEvent` into your target schema.
+* `AuditDestination<T>` writes the formatted payload to a database, queue, file, external API, or any other sink.
+* `AuditExecutionHandler` lets you register fully custom runtime handlers when a formatter/destination pair is not enough.
+
+## Registering an audit logger
+
+Use `audit {}` inside the `KtorAdmin` installation block:
+
+```kotlin
+install(KtorAdmin) {
+    audit {
+        registerDestination(
+            key = "stdout",
+            formatter = AuditFormatters.map,
+            destination = AuditDestination { payload, _ ->
+                println(payload)
+            },
+        )
+    }
+}
+```
+
+The audit listener composes with regular `AdminEventListener` registrations, so existing event listeners can keep handling thumbnails, custom workflows, or integrations while the audit logger records the same events.
+
+## Event model
+
+Every audit entry is represented as an `AuditEvent`:
+
+```kotlin
+data class AuditEvent(
+    val id: String,
+    val occurredAt: Instant,
+    val action: AuditAction,
+    val resourceType: AuditResourceType,
+    val resourceName: String,
+    val objectPrimaryKeys: List<String>,
+    val changes: List<AuditFieldChange>,
+    val attributes: Map<String, Any?>
+)
+```
+
+`action` is one of `INSERT`, `UPDATE`, or `DELETE`.
+
+`resourceType` is one of `JDBC_TABLE` or `MONGO_COLLECTION`.
+
+`changes` contains field or column values for inserts and updates. Delete events contain the deleted primary keys and an empty `changes` list.
+
+## Custom schemas
+
+Create a formatter when your destination expects a specific schema:
+
+```kotlin
+data class AuditRow(
+    val eventId: String,
+    val tableName: String,
+    val action: String,
+    val primaryKey: String?,
+    val changedFields: List<String>,
+)
+
+val rowFormatter =
+    AuditFormatter { event ->
+        AuditRow(
+            eventId = event.id,
+            tableName = event.resourceName,
+            action = event.action.name,
+            primaryKey = event.objectPrimaryKey,
+            changedFields = event.changes.filter { it.changed }.map { it.name },
+        )
+    }
+
+install(KtorAdmin) {
+    audit {
+        registerDestination(
+            key = "audit-table",
+            formatter = rowFormatter,
+            destination = AuditDestination { row, _ ->
+                auditRepository.insert(row)
+            },
+        )
+    }
+}
+```
+
+## Multiple destinations
+
+Handlers are executed concurrently for each event. A slow destination does not block other destinations from receiving the same event:
+
+```kotlin
+install(KtorAdmin) {
+    audit {
+        registerDestination("database", rowFormatter) { row, _ ->
+            auditRepository.insert(row)
+        }
+
+        registerDestination("queue", AuditFormatters.map) { payload, _ ->
+            auditQueue.publish(payload)
+        }
+    }
+}
+```
+
+## Runtime handlers
+
+Use `AuditLogger` directly when you need to add or remove handlers after application startup:
+
+```kotlin
+val auditLogger = AuditLogger()
+
+install(KtorAdmin) {
+    registerAuditLogger(auditLogger)
+}
+
+auditLogger.registerHandler(
+    object : AuditExecutionHandler {
+        override val key: String = "security-monitor"
+
+        override suspend fun handle(event: AuditEvent) {
+            securityMonitor.capture(event)
+        }
+    },
+)
+
+auditLogger.unregisterHandler("security-monitor")
+```
+
+## Failure handling
+
+By default, handler failures are collected in `AuditDispatchResult` and do not stop the admin operation or other handlers. Register an `AuditErrorHandler` to observe failures:
+
+```kotlin
+install(KtorAdmin) {
+    audit {
+        errorHandler =
+            AuditErrorHandler { result ->
+                result.failures.forEach { failure ->
+                    application.log.error("Audit handler failed: ${failure.handlerKey}", failure.cause)
+                }
+            }
+    }
+}
+```
+
+Set `failOnHandlerError = true` if audit delivery must fail the current admin event when any destination fails:
+
+```kotlin
+install(KtorAdmin) {
+    audit {
+        failOnHandlerError = true
+    }
+}
+```
+
+## Event enrichment
+
+For request-specific metadata such as actor ID, IP address, or tenant ID, create an `AuditEventListener` manually and enrich events before they are dispatched:
+
+```kotlin
+val logger = AuditLogger()
+
+install(KtorAdmin) {
+    registerEventListener(
+        AuditEventListener(logger) { event ->
+            event.copy(
+                attributes =
+                    event.attributes +
+                        mapOf(
+                            "tenant" to "default",
+                            "source" to "admin-panel",
+                        ),
+            )
+        },
+    )
+}
+```
+
+Use `attributes` for metadata that is part of your audit schema but is not produced by the database mutation itself.

--- a/sample/src/main/kotlin/ir/amirreza/Admin.kt
+++ b/sample/src/main/kotlin/ir/amirreza/Admin.kt
@@ -3,6 +3,7 @@ package ir.amirreza
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import ir.amirreza.action.MyCustomAction
+import ir.amirreza.audit.registerSampleAuditLog
 import ir.amirreza.dashboard.CustomDashboard
 import ir.amirreza.listeners.AdminListener
 import ir.amirreza.previews.ImagePreview
@@ -18,7 +19,6 @@ import ir.amirroid.ktoradmin.mongo.MongoServerAddress
 import ir.amirroid.ktoradmin.plugins.KtorAdmin
 import ir.amirroid.ktoradmin.provider.defaultvalue.uuid.UUIDDefaultValueProvider
 import ir.amirroid.ktoradmin.template.DefaultAdminTemplateSettings
-import ir.amirroid.ktoradmin.templates.fluent.FluentAdminTemplate
 import ir.amirroid.ktoradmin.tiny.TinyMCEConfig
 import ir.amirroid.ktoradmin.translator.locals.fa.PersianKtorAdminTranslator
 import org.jetbrains.exposed.v1.jdbc.Database
@@ -57,6 +57,7 @@ fun Application.configureAdmin(database: Database) {
         csrfTokenExpirationTime = 1000 * 60
         registerCustomAdminActionForAll(MyCustomAction())
         registerEventListener(AdminListener(database))
+        registerSampleAuditLog()
         canDownloadDataAsCsv = true
         canDownloadDataAsPdf = true
         tinyMCEConfig =
@@ -65,7 +66,7 @@ fun Application.configureAdmin(database: Database) {
             CustomValueMapper
         )
 
-        template = FluentAdminTemplate()
+//        template = FluentAdminTemplate()
 //        template = DefaultAdminTemplate(
 //            settings = DefaultAdminTemplateSettings(
 //                colors = lightModeColors,

--- a/sample/src/main/kotlin/ir/amirreza/audit/SampleAuditLog.kt
+++ b/sample/src/main/kotlin/ir/amirreza/audit/SampleAuditLog.kt
@@ -1,0 +1,96 @@
+package ir.amirreza.audit
+
+import ir.amirroid.ktoradmin.audit.AuditDestination
+import ir.amirroid.ktoradmin.audit.AuditErrorHandler
+import ir.amirroid.ktoradmin.audit.AuditEvent
+import ir.amirroid.ktoradmin.audit.AuditExecutionHandler
+import ir.amirroid.ktoradmin.audit.AuditFormatter
+import ir.amirroid.ktoradmin.audit.AuditFormatters
+import ir.amirroid.ktoradmin.audit.AuditLogger
+import ir.amirroid.ktoradmin.configuration.KtorAdminConfiguration
+
+data class SampleAuditRecord(
+    val eventId: String,
+    val occurredAt: String,
+    val action: String,
+    val resourceType: String,
+    val resourceName: String,
+    val primaryKeys: List<String>,
+    val changedValues: Map<String, Any?>,
+    val metadata: Map<String, Any?>,
+)
+
+object SampleAuditStore {
+    private val records = mutableListOf<SampleAuditRecord>()
+
+    val all: List<SampleAuditRecord>
+        get() = records.toList()
+
+    fun append(record: SampleAuditRecord) {
+        records.add(record)
+    }
+}
+
+fun KtorAdminConfiguration.registerSampleAuditLog(): AuditLogger =
+    audit {
+        errorHandler =
+            AuditErrorHandler { result ->
+                result.failures.forEach { failure ->
+                    println("Audit handler '${failure.handlerKey}' failed: ${failure.cause.message}")
+                }
+            }
+
+
+        registerDestination(
+            key = "sample-memory-store",
+            formatter = sampleAuditRecordFormatter,
+            destination = AuditDestination { record, _ ->
+                SampleAuditStore.append(record)
+                println("Stored audit record: $record")
+            },
+        )
+
+        registerDestination(
+            key = "sample-structured-output",
+            formatter = AuditFormatters.map,
+            destination = AuditDestination { payload, _ ->
+                println("Published audit payload: $payload")
+            },
+        )
+
+        registerHandler(SampleSecurityAuditHandler)
+    }
+
+private val sampleAuditRecordFormatter =
+    AuditFormatter { event ->
+        SampleAuditRecord(
+            eventId = event.id,
+            occurredAt = event.occurredAt.toString(),
+            action = event.action.name,
+            resourceType = event.resourceType.name,
+            resourceName = event.resourceName,
+            primaryKeys = event.objectPrimaryKeys,
+            changedValues =
+                event.changes
+                    .filter { it.changed }
+                    .associate { it.name to it.value },
+            metadata =
+                mapOf(
+                    "source" to "sample-admin-panel",
+                    "singlePrimaryKey" to event.objectPrimaryKey,
+                ),
+        )
+    }
+
+private object SampleSecurityAuditHandler : AuditExecutionHandler {
+    override val key: String = "sample-security-handler"
+
+    override suspend fun handle(event: AuditEvent) {
+        if (event.action.name == "DELETE") {
+            println(
+                "Security audit: ${event.objectPrimaryKeys.size} object(s) deleted " +
+                    "from ${event.resourceName}",
+            )
+        }
+    }
+}


### PR DESCRIPTION
  - Add normalized audit event models for JDBC and Mongo mutations
  - Add concurrent AuditLogger fan-out with custom formatters and destinations
  - Support runtime audit handler registration and removal
  - Compose multiple admin event listeners instead of allowing only one
  - Add audit logger configuration helpers
  - Add tests for dispatch, failures, runtime handlers, and listener conversion
  - Document audit log usage and add a registered sample module implementation